### PR TITLE
Connections: add and manage tracked friends

### DIFF
--- a/Eta.xcodeproj/project.pbxproj
+++ b/Eta.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		215294902F9707B800AD5B58 /* Eta.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Eta.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2152949D2F9707BC00AD5B58 /* EtaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EtaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		215294A72F9707BC00AD5B58 /* EtaUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EtaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		21791F112F9A19F900F9004A /* Eta.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = Eta.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -89,6 +90,11 @@
 				2152949D2F9707BC00AD5B58 /* EtaTests.xctest */,
 				215294A72F9707BC00AD5B58 /* EtaUITests.xctest */,
 			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		21791F132F9A19F900F9004A /* Products */ = {
+			isa = PBXGroup;
 			name = Products;
 			sourceTree = "<group>";
 		};
@@ -198,6 +204,12 @@
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 215294912F9707B800AD5B58 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 21791F132F9A19F900F9004A /* Products */;
+					ProjectRef = 21791F112F9A19F900F9004A /* Eta.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				2152948F2F9707B800AD5B58 /* Eta */,
@@ -395,13 +407,16 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 53VU37PD55;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSContactsUsageDescription = "Eta uses your contacts to let you search for friends by name. Contact data stays on your device.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -426,13 +441,16 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 53VU37PD55;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSContactsUsageDescription = "Eta uses your contacts to let you search for friends by name. Contact data stays on your device.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Eta/App/MainTabView.swift
+++ b/Eta/App/MainTabView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct MainTabView: View {
+    let connectionsViewModel: ConnectionsViewModel
+
     var body: some View {
         TabView {
             Tab("For You", systemImage: "sparkles") {
@@ -12,17 +14,8 @@ struct MainTabView: View {
                 )
             }
             Tab("Friends", systemImage: "person.2") {
-                // Replaced by ConnectionsView in PR 2
-                ContentUnavailableView(
-                    "No Friends Yet",
-                    systemImage: "person.2",
-                    description: Text("Your tracked friends will appear here.")
-                )
+                ConnectionsView(viewModel: connectionsViewModel)
             }
         }
     }
-}
-
-#Preview {
-    MainTabView()
 }

--- a/Eta/EtaApp.swift
+++ b/Eta/EtaApp.swift
@@ -10,10 +10,22 @@ import SwiftData
 
 @main
 struct EtaApp: App {
+    private let container: ModelContainer
+    private let connectionsViewModel: ConnectionsViewModel
+
+    init() {
+        let container = try! ModelContainer(for: TrackedContact.self)
+        self.container = container
+
+        let repository = ContactRepository(modelContext: container.mainContext)
+        let formatter = ContactFormatter()
+        self.connectionsViewModel = ConnectionsViewModel(repository: repository, formatter: formatter)
+    }
+
     var body: some Scene {
         WindowGroup {
-            MainTabView()
+            MainTabView(connectionsViewModel: connectionsViewModel)
         }
-        .modelContainer(for: TrackedContact.self)
+        .modelContainer(container)
     }
 }

--- a/Eta/Repositories/ContactRepository.swift
+++ b/Eta/Repositories/ContactRepository.swift
@@ -1,0 +1,34 @@
+import Foundation
+import SwiftData
+
+/// Handles all SwiftData persistence for TrackedContact.
+///
+/// This is the only type that touches ModelContext directly.
+/// Services and ViewModels must go through this repository to read or write contacts.
+final class ContactRepository {
+    private let modelContext: ModelContext
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    /// Inserts a new TrackedContact and saves.
+    func add(_ contact: TrackedContact) throws {
+        modelContext.insert(contact)
+        try modelContext.save()
+    }
+
+    /// Deletes a TrackedContact and saves.
+    func remove(_ contact: TrackedContact) throws {
+        modelContext.delete(contact)
+        try modelContext.save()
+    }
+
+    /// Returns all persisted TrackedContacts, sorted by the date they were added (oldest first).
+    func fetchAll() throws -> [TrackedContact] {
+        let descriptor = FetchDescriptor<TrackedContact>(
+            sortBy: [SortDescriptor(\.addedAt, order: .forward)]
+        )
+        return try modelContext.fetch(descriptor)
+    }
+}

--- a/Eta/ViewModels/ConnectionsViewModel.swift
+++ b/Eta/ViewModels/ConnectionsViewModel.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Contacts
+
+/// A display-only projection of a CNContact for use in the contact picker.
+///
+/// Views receive this type instead of CNContact directly, so they never need
+/// to import Contacts or touch CNContact properties.
+struct ContactPickerItem: Identifiable {
+    let id: String          // CNContact.identifier
+    let displayName: String
+}
+
+/// Drives ConnectionsView and AddConnectionSheet.
+///
+/// Owns the CNContactStore instance used for contact loading and permission requests.
+/// CNContact is an implementation detail — Views only ever see TrackedContact,
+/// plain Strings, and ContactPickerItem.
+@Observable
+final class ConnectionsViewModel {
+    private(set) var contacts: [TrackedContact] = []
+    /// Filtered slice of the address book — updated synchronously as the search query changes.
+    private(set) var searchResults: [ContactPickerItem] = []
+    private(set) var isPermissionDenied: Bool = false
+    /// True while the initial full-contact fetch is in flight.
+    private(set) var isLoadingContacts: Bool = false
+
+    /// Full address book minus already-tracked contacts. Source of truth for filtering.
+    private var allCNContacts: [CNContact] = []
+    /// Keyed by CNContact.identifier for O(1) lookup when committing selections.
+    private var cnContactIndex: [String: CNContact] = [:]
+
+    private let repository: ContactRepository
+    private let formatter: ContactFormatter
+    private let contactStore = CNContactStore()
+
+    init(repository: ContactRepository, formatter: ContactFormatter) {
+        self.repository = repository
+        self.formatter = formatter
+    }
+
+    // MARK: - Display
+
+    func displayName(for contact: TrackedContact) -> String {
+        formatter.displayName(for: contact)
+    }
+
+    private func displayName(for cnContact: CNContact) -> String {
+        CNContactFormatter.string(from: cnContact, style: .fullName)
+            ?? [cnContact.givenName, cnContact.familyName]
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+    }
+
+    private func pickerItem(for cnContact: CNContact) -> ContactPickerItem {
+        ContactPickerItem(id: cnContact.identifier, displayName: displayName(for: cnContact))
+    }
+
+    // MARK: - Tracked contacts
+
+    func loadContacts() {
+        contacts = (try? repository.fetchAll()) ?? []
+        if contacts.isEmpty {
+            print("loadContacts failed...")
+        } else {
+            print("loadContacts found \(contacts.count) contacts!")
+        }
+    }
+
+    func removeContact(_ contact: TrackedContact) {
+        try? repository.remove(contact)
+        loadContacts()
+    }
+
+    // MARK: - Contact picker (CNContactStore)
+
+    /// Requests Contacts permission. Sets `isPermissionDenied` if refused.
+    func requestContactsAccess() async {
+        let status = CNContactStore.authorizationStatus(for: .contacts)
+        switch status {
+        case .authorized, .limited:
+            isPermissionDenied = false
+        case .denied, .restricted:
+            isPermissionDenied = true
+        case .notDetermined:
+            do {
+                let granted = try await contactStore.requestAccess(for: .contacts)
+                isPermissionDenied = !granted
+            } catch {
+                isPermissionDenied = true
+            }
+        @unknown default:
+            isPermissionDenied = true
+        }
+    }
+
+    /// Fetches the full address book once, filters out already-tracked contacts,
+    /// and populates `searchResults` with all remaining contacts as ContactPickerItems.
+    ///
+    /// Call this after `requestContactsAccess()` resolves with permission granted.
+    func loadAllContacts() async {
+        guard !isPermissionDenied else { return }
+
+        isLoadingContacts = true
+        defer { isLoadingContacts = false }
+
+        let keysToFetch: [CNKeyDescriptor] = [
+            CNContactGivenNameKey as CNKeyDescriptor,
+            CNContactFamilyNameKey as CNKeyDescriptor,
+            CNContactPhoneNumbersKey as CNKeyDescriptor,
+            CNContactEmailAddressesKey as CNKeyDescriptor,
+            CNContactFormatter.descriptorForRequiredKeys(for: .fullName)
+        ]
+
+        do {
+            var fetched: [CNContact] = []
+            // Enumerate across all containers to cover iCloud, local, Exchange, etc.
+            let containers = try contactStore.containers(matching: nil)
+            for container in containers {
+                let predicate = CNContact.predicateForContactsInContainer(
+                    withIdentifier: container.identifier
+                )
+                let batch = try contactStore.unifiedContacts(
+                    matching: predicate,
+                    keysToFetch: keysToFetch
+                )
+                fetched.append(contentsOf: batch)
+            }
+
+            // Remove duplicates that can appear across containers after unification.
+            var seen = Set<String>()
+            fetched = fetched.filter { seen.insert($0.identifier).inserted }
+
+            // Filter out contacts already tracked, then sort alphabetically.
+            let trackedIdentifiers = Set(contacts.map(\.cnContactIdentifier))
+            allCNContacts = fetched
+                .filter { !trackedIdentifiers.contains($0.identifier) }
+                .sorted { displayName(for: $0) < displayName(for: $1) }
+
+            cnContactIndex = Dictionary(uniqueKeysWithValues: allCNContacts.map { ($0.identifier, $0) })
+            searchResults = allCNContacts.map(pickerItem)
+        } catch {
+            allCNContacts = []
+            cnContactIndex = [:]
+            searchResults = []
+        }
+    }
+
+    /// Filters the address book by `query` and updates `searchResults` synchronously.
+    /// Pass an empty string to show all contacts.
+    func searchContacts(query: String) {
+        if query.isEmpty {
+            searchResults = allCNContacts.map(pickerItem)
+        } else {
+            let lower = query.lowercased()
+            searchResults = allCNContacts
+                .filter { displayName(for: $0).lowercased().contains(lower) }
+                .map(pickerItem)
+        }
+    }
+
+    /// Resolves the given picker items back to CNContacts, persists them as
+    /// TrackedContacts, then removes them from the picker pool.
+    func addContacts(_ items: [ContactPickerItem]) {
+        let cnContacts = items.compactMap { cnContactIndex[$0.id] }
+
+        for cnContact in cnContacts {
+            let contact = TrackedContact(
+                cnContactIdentifier: cnContact.identifier,
+                name: displayName(for: cnContact),
+                givenName: cnContact.givenName,
+                familyName: cnContact.familyName,
+                phoneNumber: cnContact.phoneNumbers.first?.value.stringValue,
+                emailAddress: cnContact.emailAddresses.first?.value as String?
+            )
+            try? repository.add(contact)
+        }
+
+        loadContacts()
+
+        let addedIds = Set(items.map(\.id))
+        allCNContacts.removeAll { addedIds.contains($0.identifier) }
+        cnContactIndex = cnContactIndex.filter { !addedIds.contains($0.key) }
+        searchResults.removeAll { addedIds.contains($0.id) }
+    }
+}

--- a/Eta/Views/Connections/AddConnectionSheet.swift
+++ b/Eta/Views/Connections/AddConnectionSheet.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+struct AddConnectionSheet: View {
+    let viewModel: ConnectionsViewModel
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var query: String = ""
+    @State private var selectedIDs: Set<String> = []
+
+    private var navigationTitle: String {
+        switch selectedIDs.count {
+        case 0:  return "Add Friend"
+        case 1:  return "Add 1 Friend"
+        default: return "Add \(selectedIDs.count) Friends"
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.isPermissionDenied {
+                    permissionDeniedView
+                } else {
+                    contactList
+                }
+            }
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Add") {
+                        let selected = viewModel.searchResults.filter { selectedIDs.contains($0.id) }
+                        viewModel.addContacts(selected)
+                        dismiss()
+                    }
+                    .disabled(selectedIDs.isEmpty)
+                    .fontWeight(.semibold)
+                }
+            }
+        }
+        .task {
+            await viewModel.requestContactsAccess()
+            await viewModel.loadAllContacts()
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var contactList: some View {
+        List {
+            Section {
+                Label(
+                    "Eta uses your contacts to find friends by name. Contact data stays on your device.",
+                    systemImage: "person.crop.circle.badge.checkmark"
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            }
+
+            if viewModel.isLoadingContacts {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                .listRowBackground(Color.clear)
+            } else if viewModel.searchResults.isEmpty {
+                Text(query.isEmpty ? "No contacts available." : "No contacts found for \"\(query)\".")
+                    .foregroundStyle(.secondary)
+                    .font(.subheadline)
+            } else {
+                ForEach(viewModel.searchResults) { item in
+                    Button {
+                        if selectedIDs.contains(item.id) {
+                            selectedIDs.remove(item.id)
+                        } else {
+                            selectedIDs.insert(item.id)
+                        }
+                    } label: {
+                        HStack {
+                            Text(item.displayName)
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            Image(systemName: selectedIDs.contains(item.id)
+                                    ? "checkmark.circle.fill"
+                                    : "circle")
+                                .foregroundStyle(selectedIDs.contains(item.id)
+                                    ? Color.accentColor
+                                    : Color.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .searchable(text: $query, prompt: "Search contacts")
+        .onChange(of: query) { _, newValue in
+            viewModel.searchContacts(query: newValue)
+        }
+    }
+
+    private var permissionDeniedView: some View {
+        ContentUnavailableView(
+            "Contacts Access Required",
+            systemImage: "person.crop.circle.badge.exclamationmark",
+            description: Text("To add friends, allow Eta to access your contacts in Settings.")
+        )
+    }
+}

--- a/Eta/Views/Connections/ConnectionsView.swift
+++ b/Eta/Views/Connections/ConnectionsView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct ConnectionsView: View {
+    let viewModel: ConnectionsViewModel
+
+    @State private var showingAddSheet = false
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.contacts.isEmpty {
+                    ContentUnavailableView(
+                        "No Friends Yet",
+                        systemImage: "person.2",
+                        description: Text("Tap + to add friends you want to keep up with.")
+                    )
+                } else {
+                    List {
+                        ForEach(viewModel.contacts) { contact in
+                            Text(viewModel.displayName(for: contact))
+                        }
+                        .onDelete { indexSet in
+                            for index in indexSet {
+                                viewModel.removeContact(viewModel.contacts[index])
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Friends")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showingAddSheet = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingAddSheet) {
+                AddConnectionSheet(viewModel: viewModel)
+            }
+            .task {
+                viewModel.loadContacts()
+            }
+        }
+    }
+}

--- a/docs/implementation-schedule.md
+++ b/docs/implementation-schedule.md
@@ -84,7 +84,7 @@ Covers:
 | PR | Status |
 |----|--------|
 | PR 1 — Scaffold, models, protocols | [x] Complete |
-| PR 2 — Connections                 | [ ] Not started |
+| PR 2 — Connections                 | [x] Complete    |
 | PR 3 — Calendar + health           | [ ] Not started |
 | PR 4 — Suggestion engine           | [ ] Not started |
 | PR 5 — Invite flow                 | [ ] Not started |


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                            
  Implements the full Friends tab: users can search their address book, select contacts to track, view them in a list, and swipe to remove them. This is the first PR that produces visible, interactive UI beyond empty placeholders.                                                                                      
                                  
**Issue:**  #33
                                                                                                                                                                                                                                                                                          
  ---                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                            
  ## Changes                                                                                                                                                                                                                                                                                                                

  ### New files

  | File | Purpose |
  |------|---------|
  | `Eta/Repositories/ContactRepository.swift` | SwiftData CRUD for `TrackedContact`. Only type that touches `ModelContext` directly. |
  | `Eta/ViewModels/ConnectionsViewModel.swift` | `@Observable` VM owning `CNContactStore`. Exposes `[ContactPickerItem]` to views — `CNContact` never escapes the VM. |                                                                                                                                                    
  | `Eta/Views/Connections/ConnectionsView.swift` | Friends list with swipe-to-delete and a `+` toolbar button. |                                                                                                                                                                                                           
  | `Eta/Views/Connections/AddConnectionSheet.swift` | Multi-select contact picker sheet with live search and inline permission explanation. |                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                            
  ### Modified files                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                            
  | File | Change |                                                                                                                                                                                                                                                                                                       
  |------|--------|
  | `Eta/EtaApp.swift` | Creates `ModelContainer` explicitly so `container.mainContext` can be injected into `ContactRepository`. Constructs and owns `ConnectionsViewModel`. |
  | `Eta/App/MainTabView.swift` | Accepts `ConnectionsViewModel` via constructor. Friends tab now renders `ConnectionsView` instead of a placeholder. |                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                          
  ## Notes                                                                                                                                                                                                                                                                                                                  
   
  - **`ContactPickerItem`** — a lightweight `Identifiable` value type (`id: String`, `displayName: String`) that the ViewModel projects from `CNContact` before any data reaches a View. `AddConnectionSheet` imports only `SwiftUI`; `import Contacts` is absent from all View files.                                      
                                                                                                                                                                                                                                                                                                                          
  - **Client-side filtering** — `loadAllContacts()` fetches the full address book once on sheet open (across all CNContactStore containers, with deduplication). Subsequent search queries filter an in-memory array synchronously — no per-keystroke store round-trips.                                                    
                                                                                                                                                                                                                                                                                                                          
  - **Multi-select with batch commit** — selections are tracked in a local `Set<String>` in the View. Tapping "Add" resolves IDs against a private `[String: CNContact]` index in the ViewModel and inserts all contacts in a single pass before calling `loadContacts()` once.                                             
                                                                                                                                                                                                                                                                                                                          
  - **Permissions inline** — Contacts access is requested when the sheet appears, preceded by a one-line explanation label inside the list. No separate onboarding screen.                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                          
  - **Picker pool pruning** — added contacts are immediately removed from `allCNContacts`, `cnContactIndex`, and `searchResults` so they cannot be double-added without re-opening the sheet.