### PR TITLE
Calendar integration and relationship health

### DIFF
--- a/Eta.xcodeproj/project.pbxproj
+++ b/Eta.xcodeproj/project.pbxproj
@@ -410,6 +410,7 @@
 				DEVELOPMENT_TEAM = 53VU37PD55;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "Eta uses your calendar to find when you've hung out with friends.";
 				INFOPLIST_KEY_NSContactsUsageDescription = "Eta uses your contacts to let you search for friends by name. Contact data stays on your device.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -444,6 +445,7 @@
 				DEVELOPMENT_TEAM = 53VU37PD55;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "Eta uses your calendar to find when you've hung out with friends.";
 				INFOPLIST_KEY_NSContactsUsageDescription = "Eta uses your contacts to let you search for friends by name. Contact data stays on your device.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Eta/DataProviders/CalendarDataProvider.swift
+++ b/Eta/DataProviders/CalendarDataProvider.swift
@@ -1,0 +1,103 @@
+import Foundation
+import EventKit
+
+/// Supplies hangout events from Apple Calendar via EKEventStore.
+///
+/// Implements `ImplicitDataProvider`. A future social-API provider would conform
+/// to the same protocol — no changes to RelationshipService needed.
+final class CalendarDataProvider: ImplicitDataProvider {
+    private let eventStore = EKEventStore()
+
+    func requestAccess() async -> Bool {
+        let current = EKEventStore.authorizationStatus(for: .event)
+        print("[CalendarDataProvider] authorizationStatus before request: \(current.rawValue)")
+        do {
+            let granted = try await eventStore.requestFullAccessToEvents()
+            print("[CalendarDataProvider] requestFullAccessToEvents returned: \(granted)")
+            return granted
+        } catch {
+            print("[CalendarDataProvider] requestFullAccessToEvents threw: \(error)")
+            return false
+        }
+    }
+
+    /// Fetches calendar events on or after `date` and maps qualifying ones to HangoutEvents.
+    ///
+    /// The `contacts` parameter is part of the protocol contract and available for
+    /// pre-filtering, but we intentionally do not filter here: we build a ContactMatcher
+    /// for every attendee so RelationshipService can match a single event against
+    /// multiple contacts in one pass. On a personal device the total event count is small
+    /// enough that pre-filtering provides no meaningful benefit.
+    func fetchEvents(for contacts: [TrackedContact], since date: Date) async throws -> [HangoutEvent] {
+        let predicate = eventStore.predicateForEvents(
+            withStart: date,
+            end: Date(),
+            calendars: eventStore.calendars(for: .event)
+        )
+        let ekEvents = eventStore.events(matching: predicate)
+        
+        print("Searching over \(ekEvents.count) events")
+        
+        let results: [HangoutEvent] = ekEvents.compactMap { event in
+            guard qualifies(event) else { return nil }
+            
+            let matchers = buildMatchers(for: event)
+            guard !matchers.isEmpty else { return nil }
+            
+            return HangoutEvent(
+                eventIdentifier: event.eventIdentifier ?? UUID().uuidString,
+                title: event.title ?? "",
+                startDate: event.startDate,
+                endDate: event.endDate,
+                participantMatchers: matchers
+            )
+        }
+        
+        print("Found \(results.count) hangout events.")
+        
+        return results
+    }
+    
+    // MARK: - Private helpers
+
+    /// Returns true when the event passes all three hangout filters from CLAUDE.md:
+    /// not all-day, duration ≥ 15 min, has at least one attendee.
+    private func qualifies(_ event: EKEvent) -> Bool {
+        guard !event.isAllDay,
+              let end = event.endDate,
+              end.timeIntervalSince(event.startDate) >= 15 * 60,
+              let attendees = event.attendees, !attendees.isEmpty
+        else { return false }
+        return true
+    }
+
+    /// Builds one ContactMatcher per attendee, skipping the current user and
+    /// anyone who declined. Prefers email when available; falls back to name.
+    private func buildMatchers(for event: EKEvent) -> [ContactMatcher] {
+        guard let attendees = event.attendees else { return [] }
+
+        return attendees.compactMap { participant in
+            // Exclude the device owner — we want who they hung out WITH.
+            guard !participant.isCurrentUser else { return nil }
+            // Exclude non-persons (rooms, resources).
+            guard participant.participantType == .person else { return nil }
+            // Exclude people who explicitly said no.
+            guard participant.participantStatus != .declined else { return nil }
+
+            let urlString = participant.url.absoluteString
+            if urlString.hasPrefix("mailto:") {
+                let email = String(urlString.dropFirst("mailto:".count)).lowercased()
+                if !email.isEmpty { return .email(email) }
+            }
+
+            // No usable email URL — fall back to display name matching.
+            // Note: EKParticipant does not expose phone numbers, so name is the
+            // only available fallback for contacts without email addresses.
+            if let name = participant.name, !name.isEmpty {
+                return .name(name.lowercased())
+            }
+
+            return nil
+        }
+    }
+}

--- a/Eta/EtaApp.swift
+++ b/Eta/EtaApp.swift
@@ -19,7 +19,16 @@ struct EtaApp: App {
 
         let repository = ContactRepository(modelContext: container.mainContext)
         let formatter = ContactFormatter()
-        self.connectionsViewModel = ConnectionsViewModel(repository: repository, formatter: formatter)
+        let calendarDataProvider = CalendarDataProvider()
+        let relationshipService = RelationshipService(
+            providers: [calendarDataProvider],
+            repository: repository
+        )
+        self.connectionsViewModel = ConnectionsViewModel(
+            repository: repository,
+            formatter: formatter,
+            relationshipService: relationshipService
+        )
     }
 
     var body: some Scene {

--- a/Eta/Models/HangoutEvent.swift
+++ b/Eta/Models/HangoutEvent.swift
@@ -1,12 +1,46 @@
 import Foundation
 
-/// A single calendar event that has been parsed and identified as a potential hangout.
+// Matching attendees to TrackedContacts requires checking different fields depending
+// on what data is available. We originally considered two parallel arrays
+// (participantEmails and participantNames), but parallel arrays force the caller to
+// know which array to compare against which contact property — the matching rule is
+// split across two sites. Instead, each attendee becomes a ContactMatcher: a
+// self-contained predicate that knows both the value and how to compare it.
+// Adding a new signal (e.g. phone number, once EventKit exposes it) is a new case
+// here — no changes needed in RelationshipService or CalendarDataProvider's call sites.
+
+enum ContactMatcher {
+    /// A lowercased email address extracted from an EKParticipant mailto: URL.
+    case email(String)
+    /// A lowercased display name in "GivenName FamilyName" order from EKParticipant.name.
+    case name(String)
+
+    /// Returns true if this matcher identifies `contact` as the attendee.
+    func matches(_ contact: TrackedContact) -> Bool {
+        switch self {
+        case .email(let email):
+            return contact.emailAddress?.lowercased() == email
+
+        case .name(let name):
+            // Construct the contact's name in the same order used by EKParticipant —
+            // given-first, family-second — rather than using contact.name, which may
+            // be locale-formatted (e.g. "Smith John" in some regions).
+            let full = "\(contact.givenName) \(contact.familyName)"
+                .trimmingCharacters(in: .whitespaces)
+                .lowercased()
+            return name == full
+        }
+    }
+}
+
+/// A single calendar event identified as a candidate hangout.
 struct HangoutEvent: Identifiable {
     var id: String { eventIdentifier }
     var eventIdentifier: String
     var title: String
     var startDate: Date
     var endDate: Date
-    /// Emails of attendees — matched against TrackedContact.emailAddress to associate contacts.
-    var participantEmails: [String]
+    /// One matcher per attendee. RelationshipService calls matcher.matches(contact)
+    /// to associate this event with each TrackedContact.
+    var participantMatchers: [ContactMatcher]
 }

--- a/Eta/Models/RelationshipHealth.swift
+++ b/Eta/Models/RelationshipHealth.swift
@@ -6,6 +6,8 @@ struct RelationshipHealth {
     var contact: TrackedContact
     /// Date of the most recent hangout event found in the look-back window.
     var lastHangoutDate: Date?
+    /// Title of the most recent hangout event — used to personalise the health label.
+    var lastHangoutTitle: String?
     /// Number of hangouts within the look-back window (default: 90 days).
     var hangoutCount: Int
     /// Ranking score — higher means more overdue for a hangout.

--- a/Eta/Services/RelationshipService.swift
+++ b/Eta/Services/RelationshipService.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Computes RelationshipHealth for every tracked contact by fanning out
+/// to all registered ImplicitDataProviders and correlating their events.
+final class RelationshipService {
+    private let providers: [any ImplicitDataProvider]
+    private let repository: ContactRepository
+
+    init(providers: [any ImplicitDataProvider], repository: ContactRepository) {
+        self.providers = providers
+        self.repository = repository
+    }
+
+    /// Returns one RelationshipHealth per active tracked contact.
+    ///
+    /// - Parameter lookBackDays: How far back to search for hangout events (default 90 days).
+    ///   Contacts with no events in this window receive a nil lastHangoutDate and
+    ///   the maximum possible score, surfacing them as most overdue.
+    func computeHealth(lookBackDays: Int = 90) async -> [RelationshipHealth] {
+        let contacts = (try? repository.fetchAll()) ?? []
+        guard !contacts.isEmpty else { return [] }
+        
+        print("Computing health")
+
+        let since = Calendar.current.date(byAdding: .day, value: -lookBackDays, to: .now) ?? .now
+
+        // Fan out to all providers concurrently. A provider that denies access or
+        // throws contributes an empty result — one bad provider degrades gracefully
+        // rather than aborting the whole computation.
+        var allEvents: [HangoutEvent] = []
+        await withTaskGroup(of: [HangoutEvent].self) { group in
+            for provider in providers {
+                group.addTask {
+                    print("[RelationshipService] requesting access from \(type(of: provider))")
+                    let hasAccess = await provider.requestAccess()
+                    print("[RelationshipService] \(type(of: provider)) access granted: \(hasAccess)")
+                    guard hasAccess else { return [] }
+                    print("[RelationshipService] calling fetchEvents on \(type(of: provider))")
+                    return (try? await provider.fetchEvents(for: contacts, since: since)) ?? []
+                }
+            }
+            for await events in group {
+                allEvents.append(contentsOf: events)
+            }
+        }
+
+        // Deduplicate by eventIdentifier — the same event can be returned by
+        // multiple providers if they overlap (e.g. CalDAV + iCloud).
+        var seen = Set<String>()
+        allEvents = allEvents.filter { seen.insert($0.eventIdentifier).inserted }
+        
+        print("[RelationshipService] Found \(allEvents.count) events.")
+
+        return contacts.map { contact in
+            let matching = allEvents.filter { event in
+                event.participantMatchers.contains { $0.matches(contact) }
+            }
+            return RelationshipHealth(
+                contact: contact,
+                lastHangoutDate: matching.map(\.startDate).max(),
+                hangoutCount: matching.count,
+                score: score(lastHangoutDate: matching.map(\.startDate).max(),
+                             lookBackDays: lookBackDays)
+            )
+        }
+    }
+
+    // MARK: - Scoring
+
+    // Score = days since last hangout, defaulting to the full look-back window when
+    // there is no recorded hangout. Higher means more overdue.
+    // This is intentionally simple for MVP — it lives here as a private method so
+    // the formula can be swapped without touching any call sites.
+    private func score(lastHangoutDate: Date?, lookBackDays: Int) -> Double {
+        guard let last = lastHangoutDate else { return Double(lookBackDays) }
+        let days = Calendar.current.dateComponents([.day], from: last, to: .now).day ?? lookBackDays
+        return Double(max(0, days))
+    }
+}

--- a/Eta/Services/RelationshipService.swift
+++ b/Eta/Services/RelationshipService.swift
@@ -55,12 +55,14 @@ final class RelationshipService {
             let matching = allEvents.filter { event in
                 event.participantMatchers.contains { $0.matches(contact) }
             }
+            let lastEvent = matching.max(by: { $0.startDate < $1.startDate })
+            let lastHangoutDate = lastEvent?.startDate
             return RelationshipHealth(
                 contact: contact,
-                lastHangoutDate: matching.map(\.startDate).max(),
+                lastHangoutDate: lastHangoutDate,
+                lastHangoutTitle: lastEvent?.title.isEmpty == false ? lastEvent?.title : nil,
                 hangoutCount: matching.count,
-                score: score(lastHangoutDate: matching.map(\.startDate).max(),
-                             lookBackDays: lookBackDays)
+                score: score(lastHangoutDate: lastHangoutDate, lookBackDays: lookBackDays)
             )
         }
     }

--- a/Eta/ViewModels/ConnectionsViewModel.swift
+++ b/Eta/ViewModels/ConnectionsViewModel.swift
@@ -23,6 +23,8 @@ final class ConnectionsViewModel {
     private(set) var isPermissionDenied: Bool = false
     /// True while the initial full-contact fetch is in flight.
     private(set) var isLoadingContacts: Bool = false
+    /// Health scores keyed by TrackedContact.id for O(1) per-row lookup.
+    private(set) var healthScores: [UUID: RelationshipHealth] = [:]
 
     /// Full address book minus already-tracked contacts. Source of truth for filtering.
     private var allCNContacts: [CNContact] = []
@@ -31,11 +33,13 @@ final class ConnectionsViewModel {
 
     private let repository: ContactRepository
     private let formatter: ContactFormatter
+    private let relationshipService: RelationshipService
     private let contactStore = CNContactStore()
 
-    init(repository: ContactRepository, formatter: ContactFormatter) {
+    init(repository: ContactRepository, formatter: ContactFormatter, relationshipService: RelationshipService) {
         self.repository = repository
         self.formatter = formatter
+        self.relationshipService = relationshipService
     }
 
     // MARK: - Display
@@ -69,6 +73,29 @@ final class ConnectionsViewModel {
     func removeContact(_ contact: TrackedContact) {
         try? repository.remove(contact)
         loadContacts()
+    }
+
+    // MARK: - Relationship health
+
+    /// Fetches health scores for all tracked contacts via RelationshipService.
+    /// Triggers Calendar permission request on first call.
+    func loadHealthScores() async {
+        let scores = await relationshipService.computeHealth()
+        healthScores = Dictionary(uniqueKeysWithValues: scores.map { ($0.contact.id, $0) })
+    }
+
+    /// Returns a human-readable summary of when the user last hung out with this contact,
+    /// or nil if health data hasn't been loaded yet.
+    func healthLabel(for contact: TrackedContact) -> String? {
+        guard let health = healthScores[contact.id] else { return nil }
+        guard let days = health.daysSinceLastHangout else {
+            return "No hangouts on record"
+        }
+        switch days {
+        case 0:  return "Seen today"
+        case 1:  return "Seen yesterday"
+        default: return "Last seen \(days) days ago"
+        }
     }
 
     // MARK: - Contact picker (CNContactStore)

--- a/Eta/ViewModels/ConnectionsViewModel.swift
+++ b/Eta/ViewModels/ConnectionsViewModel.swift
@@ -91,10 +91,23 @@ final class ConnectionsViewModel {
         guard let days = health.daysSinceLastHangout else {
             return "No hangouts on record"
         }
+
+        // Append the event title in lowercase to read naturally:
+        // "Last seen 2 days ago at coffee with Sarah"
+        // Lowercasing only the first character preserves proper nouns and acronyms
+        // within the title (e.g. "WWDC dinner" → "at WWDC dinner").
+        let titleSuffix: String
+        if let title = health.lastHangoutTitle, !title.isEmpty {
+            let downcased = title.prefix(1).lowercased() + title.dropFirst()
+            titleSuffix = " at \(downcased)"
+        } else {
+            titleSuffix = ""
+        }
+
         switch days {
-        case 0:  return "Seen today"
-        case 1:  return "Seen yesterday"
-        default: return "Last seen \(days) days ago"
+        case 0:  return "Seen today\(titleSuffix)"
+        case 1:  return "Seen yesterday\(titleSuffix)"
+        default: return "Last seen \(days) days ago\(titleSuffix)"
         }
     }
 

--- a/Eta/Views/Connections/ConnectionsView.swift
+++ b/Eta/Views/Connections/ConnectionsView.swift
@@ -17,7 +17,7 @@ struct ConnectionsView: View {
                 } else {
                     List {
                         ForEach(viewModel.contacts) { contact in
-                            Text(viewModel.displayName(for: contact))
+                            ContactRow(contact: contact, viewModel: viewModel)
                         }
                         .onDelete { indexSet in
                             for index in indexSet {
@@ -42,7 +42,47 @@ struct ConnectionsView: View {
             }
             .task {
                 viewModel.loadContacts()
+                await viewModel.loadHealthScores()
             }
         }
+    }
+}
+
+// MARK: - Contact row
+
+private struct ContactRow: View {
+    let contact: TrackedContact
+    let viewModel: ConnectionsViewModel
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(healthColor)
+                .frame(width: 10, height: 10)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(viewModel.displayName(for: contact))
+                    .font(.body)
+
+                if let label = viewModel.healthLabel(for: contact) {
+                    Text(label)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    // Color thresholds are a display concern — they live in the View, not the ViewModel.
+    // ≤ 14 days: green (healthy), ≤ 30 days: yellow (getting stale), > 30 or no data: red.
+    private var healthColor: Color {
+        guard let health = viewModel.healthScores[contact.id],
+              let days = health.daysSinceLastHangout else {
+            return .gray
+        }
+        if days <= 14 { return .green }
+        if days <= 30 { return .yellow }
+        return .red
     }
 }

--- a/docs/implementation-schedule.md
+++ b/docs/implementation-schedule.md
@@ -85,7 +85,7 @@ Covers:
 |----|--------|
 | PR 1 — Scaffold, models, protocols | [x] Complete |
 | PR 2 — Connections                 | [x] Complete    |
-| PR 3 — Calendar + health           | [ ] Not started |
+| PR 3 — Calendar + health           | [x] Complete    |
 | PR 4 — Suggestion engine           | [ ] Not started |
 | PR 5 — Invite flow                 | [ ] Not started |
 | PR 6 — Hardening                   | [ ] Not started |


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                            
  Implements Calendar integration and relationship health scoring. The Friends tab now shows a colored health indicator and a personalized "last seen" label for each tracked contact, derived from matching Apple Calendar events. Permission is requested inline when the tab first loads.              

**Issues:** #34, #33                  
   
**Note:** Because we needed identify a hangout with a connection by looking at Calendar events, we need the event to have attendees. This is not a feature that's available on the simulator, so the changes in this PR are only visible when the build target is an actual device.

  ---                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                          
  ## Changes                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                          
  ### New files

  | File | Purpose |
  |------|---------|
  | `Eta/DataProviders/CalendarDataProvider.swift` | Concrete `ImplicitDataProvider` backed by `EKEventStore`. Fetches events, applies the three hangout filters (no all-day, ≥ 15 min duration, has attendees), and builds a `[ContactMatcher]` per event from attendee email and display name fields. |
  | `Eta/Services/RelationshipService.swift` | Fans out to all registered `ImplicitDataProvider`s concurrently via `TaskGroup`, deduplicates events by identifier, then computes a `RelationshipHealth` per tracked contact. |                                                                                              
                                                                                                                                                                                                                                                                                                                            
  ### Modified files                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                            
  | File | Change |                                                                                                                                                                                                                                                                                                       
  |------|--------|
  | `Eta/Models/HangoutEvent.swift` | Replaced `participantEmails: [String]` with `participantMatchers: [ContactMatcher]`. Added `ContactMatcher` enum with `.email` and `.name` cases, each carrying a self-contained `matches(_ contact:)` predicate. |
  | `Eta/Models/RelationshipHealth.swift` | Added `lastHangoutTitle: String?` — the title of the most recent matching calendar event, used to personalise the health label. |                                                                                                                                               
  | `Eta/ViewModels/ConnectionsViewModel.swift` | Injected `RelationshipService` via constructor. Added `healthScores: [UUID: RelationshipHealth]`, `loadHealthScores() async`, and `healthLabel(for:) -> String?`. |                                                                                                       
  | `Eta/Views/Connections/ConnectionsView.swift` | Each list row now renders a colored dot and a health label subtitle. Extracted to a private `ContactRow` subview. `.task` extended to call `loadHealthScores()` after `loadContacts()`. |                                                                               
  | `Eta/EtaApp.swift` | Constructs `CalendarDataProvider` and `RelationshipService`; passes `RelationshipService` into `ConnectionsViewModel`. |                                                                                                                                                                           
  | `Eta.xcodeproj/project.pbxproj` | Added `NSCalendarsFullAccessUsageDescription` to both Debug and Release build configurations. Without this key, `requestFullAccessToEvents()` throws before the system permission dialog is shown. |                                                                                  
                                                                                                                                                                                                                                                                                                                            
  ### UI changes                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                            
  **Friends tab — contact list rows**                                                                                                                                                                                                                                                                                       
   
  | Before | After |                                                                                                                                                                                                                                                                                                        
  |--------|-------|                                                                                                                                                                                                                                                                                                      
  | ![Contact list before — name only](https://github.com/user-attachments/assets/107bdbc2-3ccf-453a-a0aa-7330568f05cf) | ![Contact list after — colored dot, name, and last-seen label](https://github.com/user-attachments/assets/b018b1d7-218c-41cf-b286-4fab3f330f2c) |

                                                                                                                                                                                                                                                                                    
  **Health label examples**
                                                                                                                                                                                                                                                                                                                            
  | State | Label |                                                                                                                                                                                                                                                                                                       
  |-------|-------|
  | Seen today | `Seen today at morning coffee` |
  | Seen recently | `Seen yesterday at lunch with the team` |                                                                                                                                                                                                                                                               
  | Getting stale | `Last seen 18 days ago at dinner` |                                                                                                                                                                                                                                                                     
  | No calendar data | `No hangouts on record` |                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                            
  ---                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                            
  ## Notes                                                                                                                                                                                                                                                                                                                

  - **`ContactMatcher` replaces parallel arrays** — an earlier design used separate `participantEmails: [String]` and `participantNames: [String]` arrays. Parallel arrays split the matching rule across two sites and require the caller to know which field maps to which contact property. `ContactMatcher` is a        
  self-contained predicate: adding a new signal (e.g. phone number if EventKit ever exposes it) is a new enum case, with no changes needed in `RelationshipService` or `CalendarDataProvider`'s call sites.
                                                                                                                                                                                                                                                                                                                            
  - **Email-or-name matching** — `EKParticipant` exposes a `mailto:` URL and a display name, but no phone number. The `.email` case is preferred when available; `.name` is the fallback for contacts without an email address. Name comparison is exact and case-insensitive, using `givenName + " " + familyName` rather  
  than the pre-formatted `contact.name` field, which may use locale-specific ordering.
                                                                                                                                                                                                                                                                                                                            
  - **Scoring formula** — `score = Double(daysSinceLastHangout ?? lookBackDays)`. Simple for MVP; isolated to a private method in `RelationshipService` so it can be replaced without touching any call sites.                                                                                                              
   
  - **Health label personalisation** — the event title is appended with only its first character downcased (`"WWDC Dinner"` → `"at WWDC Dinner"`, not `"at wWDC Dinner"`), so the label reads as natural prose while preserving acronyms and proper nouns mid-title.                                                        
                                                                                                                                                                                                                                                                                                                          
  - **Calendar permission denial degrades gracefully** — if access is denied, `RelationshipService` receives an empty event list and all contacts show `"No hangouts on record"`. No blocking UI is shown; full denial handling is scoped to a later PR.