### PR TITLE
Suggest an activity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,13 @@ Read it before writing any new file. Follow it strictly unless the user explicit
 A lightweight iOS app that helps users maintain friendships by reducing friction around
 scheduling in-person hangouts. The core loop:
 
-**Analyze relationship data → surface a smart suggestion → make it easy to send an invite.**
+**Detect a free slot + identify an overdue friend → surface a time-specific suggestion → make it easy to send an invite.**
 
-MVP data source: Apple Calendar (implicit signals only).
+A suggestion requires both signals simultaneously: a gap in the user's near-term calendar
+AND a contact whose relationship health score exceeds a recency threshold. Either signal
+alone produces no suggestion — the inbox stays empty.
+
+MVP data source: Apple Calendar (implicit signals only — past events for health, upcoming gaps for opportunity).
 MVP suggestion engine: rules-based (not ML).
 MVP invite mechanism: pre-filled iMessage via URL scheme.
 
@@ -163,12 +167,14 @@ EtaApp
  ├─ CalendarDataProvider()
  ├─ RelationshipService(providers: [CalendarDataProvider], repository: ContactRepository)
  ├─ RulesSuggestionStrategy()
- ├─ SuggestionService(relationship: RelationshipService, strategy: RulesSuggestionStrategy)
+ ├─ SuggestionService(calendar: CalendarDataProvider, relationship: RelationshipService, strategy: RulesSuggestionStrategy)
  ├─ iMessageInviteProvider()
  ├─ InviteService(provider: iMessageInviteProvider)
- ├─ SuggestionViewModel(suggestion: SuggestionService, invite: InviteService, formatter: ContactFormatter)
- └─ ConnectionsViewModel(repository: ContactRepository, formatter: ContactFormatter)
+ ├─ SuggestionViewModel(suggestionService: SuggestionService, inviteService: InviteService, formatter: ContactFormatter)
+ └─ ConnectionsViewModel(repository: ContactRepository, formatter: ContactFormatter, relationshipService: RelationshipService)
 ```
+
+`CalendarDataProvider` is injected into both `RelationshipService` (as an `ImplicitDataProvider` for historical event fetching) and `SuggestionService` (concretely, for free slot detection). A single instance is shared between both.
 
 ViewModels are created in `EtaApp` and passed into views as constructor arguments
 or via `.environment()` if needed across the tab hierarchy.
@@ -201,7 +207,9 @@ struct HangoutEvent {
     var title: String
     var startDate: Date
     var endDate: Date
-    var participantEmails: [String]   // Matched against TrackedContact.emailAddress
+    // One ContactMatcher per attendee — each encapsulates a value and a matching rule.
+    // See ContactMatcher enum (defined alongside HangoutEvent) for .email and .name cases.
+    var participantMatchers: [ContactMatcher]
 }
 ```
 
@@ -211,6 +219,7 @@ struct HangoutEvent {
 struct RelationshipHealth {
     var contact: TrackedContact
     var lastHangoutDate: Date?
+    var lastHangoutTitle: String?     // Title of most recent event — used for personalised labels
     var hangoutCount: Int             // In the look-back window (default: 90 days)
     var score: Double                 // Higher = more overdue. Used for ranking.
 }
@@ -223,6 +232,7 @@ struct Suggestion {
     var contact: TrackedContact
     var activity: Activity
     var reason: String                // Human-readable, e.g. "You haven't hung out in 3 weeks"
+    var proposedTime: DateInterval    // The specific free slot that triggered this suggestion
     var generatedAt: Date
 }
 ```
@@ -278,22 +288,42 @@ Both permission requests must be preceded by a brief in-context explanation
 
 ## Suggestion lifecycle
 
-1. `SuggestionViewModel` calls `SuggestionService.generateSuggestion()` on:
-   - App foreground (via `scenePhase` observation in the ViewModel)
+1. `SuggestionViewModel.refresh()` is called on:
+   - Initial load (`.task` in `SuggestionView`)
+   - App foreground — `SuggestionView` observes `@Environment(\.scenePhase)` and calls `refresh()` when the scene becomes `.active`. Scene phase is observed in the View, not the ViewModel, so the ViewModel stays free of SwiftUI and UIKit imports.
    - Explicit user pull-to-refresh
-2. `SuggestionService` calls `RelationshipService.computeHealth()` which fans out to all `ImplicitDataProvider`s
-3. Result flows back to `SuggestionViewModel` and updates the view
+2. `SuggestionService.generateSuggestion()` checks **both signals** in order:
+   a. Calls `CalendarDataProvider.findFreeSlot(within: 3)` — looks up to 3 days ahead for a gap ≥ 1 hour during 9am–9pm. If none → returns nil immediately.
+   b. Calls `RelationshipService.computeHealth()` to get ranked health scores.
+   c. Calls `strategy.suggest(from: healthScores)` — the strategy returns nil if no contact exceeds the recency threshold (score < 7, i.e. seen within the last week). If nil → returns nil.
+   d. Attaches `proposedTime` from step (a) to the strategy's result and returns the complete `Suggestion`.
+3. Result (or nil) flows back to `SuggestionViewModel` — view renders the card or the empty inbox state.
+4. User taps **"Maybe Later"** → `SuggestionViewModel.dismiss()` sets `suggestion = nil`. Nothing is persisted; the next `refresh()` recomputes from scratch.
 
 ---
 
 ## Calendar event → hangout matching
 
 `CalendarDataProvider` counts an event as a hangout with a `TrackedContact` when:
-- The event has at least one attendee whose email matches `TrackedContact.emailAddress` (case-insensitive)
 - The event is not an all-day event (all-day events are likely non-personal)
 - The event duration is ≥ 15 minutes
+- At least one attendee is identified as a tracked contact via `ContactMatcher`
 
-Events with no attendee data are ignored — no fuzzy title matching.
+`ContactMatcher` tries two signals per attendee, in order:
+1. **Email** — extracted from `EKParticipant.url` (`mailto:` prefix stripped, lowercased). Matched against `TrackedContact.emailAddress`.
+2. **Name** — `EKParticipant.name` lowercased, matched against `"\(givenName) \(familyName)"` constructed in given-first order (not `contact.name`, which may be locale-formatted). `EKParticipant` does not expose phone numbers, so name is the only fallback.
+
+Events with no attendee data are ignored. The current user and declined attendees are excluded from matcher construction.
+
+## Free slot detection
+
+`CalendarDataProvider.findFreeSlot(within:minimumDuration:)` finds the earliest gap in the user's calendar suitable for a hangout:
+- Searches each day from now up to `lookAheadDays` (default 3)
+- Search window per day: 9am–9pm
+- Minimum gap duration: 1 hour (configurable via `minimumDuration` parameter)
+- Returns the first qualifying `DateInterval`, or nil if none found
+
+This method is **not** on the `ImplicitDataProvider` protocol — free slot detection is a distinct capability from historical event fetching, and no other data source is expected to provide it. `SuggestionService` depends on `CalendarDataProvider` concretely for this method.
 
 ---
 
@@ -320,6 +350,7 @@ CNContactFormatter.string(from: cnContact, style: .fullName)
 
 - `ContactRepository` — SwiftData is stable; no repository protocol needed now
 - Relationship scoring formula — lives as a private method inside `RelationshipService`; extract to a `RelationshipScorer` protocol only if the formula needs to vary per user or be swapped
+- Free slot detection — `CalendarDataProvider.findFreeSlot` is a concrete method, not behind a protocol. If a second calendar source (e.g. Google Calendar) ever needs to contribute free-slot data, extract a `FreeTimeProvider` protocol at that point.
 - Navigation routing — NavigationStack in-view is sufficient at this scale
 - Dependency injection container — constructor injection is explicit enough for a team of 5
 
@@ -349,3 +380,4 @@ CNContactFormatter.string(from: cnContact, style: .fullName)
 9. Keep the `Activity` enum hardcoded until the user explicitly asks for dynamic activities.
 10. When in doubt about scope, do less and ask — this is an MVP.
 11. Never call `CNContactFormatter` directly in a View or ViewModel — always go through `ContactFormatter.displayName(for:)`.
+12. Scene phase is observed in Views via `@Environment(\.scenePhase)`, not in ViewModels. ViewModels expose a plain `refresh() async` method; the View calls it from `.onChange(of: scenePhase)`.

--- a/Eta/App/MainTabView.swift
+++ b/Eta/App/MainTabView.swift
@@ -2,16 +2,12 @@ import SwiftUI
 
 struct MainTabView: View {
     let connectionsViewModel: ConnectionsViewModel
+    let suggestionViewModel: SuggestionViewModel
 
     var body: some View {
         TabView {
             Tab("For You", systemImage: "sparkles") {
-                // Replaced by SuggestionView in PR 4
-                ContentUnavailableView(
-                    "Suggestions Coming Soon",
-                    systemImage: "sparkles",
-                    description: Text("Add friends first, then we'll find the right hangout for you.")
-                )
+                SuggestionView(viewModel: suggestionViewModel)
             }
             Tab("Friends", systemImage: "person.2") {
                 ConnectionsView(viewModel: connectionsViewModel)

--- a/Eta/DataProviders/CalendarDataProvider.swift
+++ b/Eta/DataProviders/CalendarDataProvider.swift
@@ -58,6 +58,58 @@ final class CalendarDataProvider: ImplicitDataProvider {
         return results
     }
     
+    // MARK: - Free slot detection
+
+    /// Returns the earliest free slot in the user's calendar within `lookAheadDays` days
+    /// that is at least `minimumDuration` seconds long, or nil if none is found.
+    ///
+    /// Search window per day: 9am–9pm. For today, the window starts at the current time
+    /// if it falls within the window.
+    ///
+    /// This method is not on ImplicitDataProvider — free slot detection is a distinct
+    /// capability from historical event fetching. SuggestionService depends on this
+    /// concretely. See CLAUDE.md "What is intentionally NOT abstracted".
+    func findFreeSlot(within lookAheadDays: Int = 3, minimumDuration: TimeInterval = 3600) -> DateInterval? {
+        let cal = Calendar.current
+        let now = Date()
+
+        for dayOffset in 0..<lookAheadDays {
+            guard let day = cal.date(byAdding: .day, value: dayOffset, to: now),
+                  let windowStart = cal.date(bySettingHour: 9, minute: 0, second: 0, of: day),
+                  let windowEnd   = cal.date(bySettingHour: 21, minute: 0, second: 0, of: day)
+            else { continue }
+
+            // On the current day, don't look at time that has already passed.
+            let searchStart = (dayOffset == 0) ? max(now, windowStart) : windowStart
+            guard searchStart + minimumDuration <= windowEnd else { continue }
+
+            let predicate = eventStore.predicateForEvents(
+                withStart: windowStart,
+                end: windowEnd,
+                calendars: eventStore.calendars(for: .event)
+            )
+            let busyEvents = eventStore.events(matching: predicate)
+                .filter { !$0.isAllDay }
+                .sorted { $0.startDate < $1.startDate }
+
+            // Walk through busy blocks and find the first gap that fits.
+            var cursor = searchStart
+            for event in busyEvents {
+                let blockStart = max(event.startDate, windowStart)
+                let blockEnd   = min(event.endDate,   windowEnd)
+                if cursor + minimumDuration <= blockStart {
+                    return DateInterval(start: cursor, duration: minimumDuration)
+                }
+                if blockEnd > cursor { cursor = blockEnd }
+            }
+            // Check remaining time after all events.
+            if cursor + minimumDuration <= windowEnd {
+                return DateInterval(start: cursor, duration: minimumDuration)
+            }
+        }
+        return nil
+    }
+
     // MARK: - Private helpers
 
     /// Returns true when the event passes all three hangout filters from CLAUDE.md:

--- a/Eta/EtaApp.swift
+++ b/Eta/EtaApp.swift
@@ -12,6 +12,7 @@ import SwiftData
 struct EtaApp: App {
     private let container: ModelContainer
     private let connectionsViewModel: ConnectionsViewModel
+    private let suggestionViewModel: SuggestionViewModel
 
     init() {
         let container = try! ModelContainer(for: TrackedContact.self)
@@ -20,20 +21,35 @@ struct EtaApp: App {
         let repository = ContactRepository(modelContext: container.mainContext)
         let formatter = ContactFormatter()
         let calendarDataProvider = CalendarDataProvider()
+
         let relationshipService = RelationshipService(
             providers: [calendarDataProvider],
             repository: repository
         )
+        let rulesStrategy = RulesSuggestionStrategy()
+        let suggestionService = SuggestionService(
+            calendar: calendarDataProvider,
+            relationshipService: relationshipService,
+            strategy: rulesStrategy
+        )
+
         self.connectionsViewModel = ConnectionsViewModel(
             repository: repository,
             formatter: formatter,
             relationshipService: relationshipService
         )
+        self.suggestionViewModel = SuggestionViewModel(
+            suggestionService: suggestionService,
+            formatter: formatter
+        )
     }
 
     var body: some Scene {
         WindowGroup {
-            MainTabView(connectionsViewModel: connectionsViewModel)
+            MainTabView(
+                connectionsViewModel: connectionsViewModel,
+                suggestionViewModel: suggestionViewModel
+            )
         }
         .modelContainer(container)
     }

--- a/Eta/Models/Suggestion.swift
+++ b/Eta/Models/Suggestion.swift
@@ -7,5 +7,8 @@ struct Suggestion {
     var activity: Activity
     /// Human-readable rationale shown to the user, e.g. "You haven't hung out in 3 weeks".
     var reason: String
+    /// The specific free calendar slot that triggered this suggestion.
+    /// Set by SuggestionService after the strategy picks the contact and activity.
+    var proposedTime: DateInterval
     var generatedAt: Date
 }

--- a/Eta/Services/RelationshipService.swift
+++ b/Eta/Services/RelationshipService.swift
@@ -20,8 +20,6 @@ final class RelationshipService {
         let contacts = (try? repository.fetchAll()) ?? []
         guard !contacts.isEmpty else { return [] }
         
-        print("Computing health")
-
         let since = Calendar.current.date(byAdding: .day, value: -lookBackDays, to: .now) ?? .now
 
         // Fan out to all providers concurrently. A provider that denies access or
@@ -49,8 +47,6 @@ final class RelationshipService {
         var seen = Set<String>()
         allEvents = allEvents.filter { seen.insert($0.eventIdentifier).inserted }
         
-        print("[RelationshipService] Found \(allEvents.count) events.")
-
         return contacts.map { contact in
             let matching = allEvents.filter { event in
                 event.participantMatchers.contains { $0.matches(contact) }

--- a/Eta/Services/SuggestionService.swift
+++ b/Eta/Services/SuggestionService.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Generates a hangout suggestion by combining two signals:
+/// 1. Opportunity — a free slot in the user's near-term calendar (via CalendarDataProvider)
+/// 2. Need       — a contact whose relationship health score is above the recency threshold
+///
+/// Both signals must be present. If either is absent, generateSuggestion() returns nil
+/// and the For You inbox remains empty.
+///
+/// SuggestionService depends on CalendarDataProvider concretely (not via a protocol)
+/// for free slot detection, since that capability is distinct from ImplicitDataProvider's
+/// historical event fetching and no second implementation is anticipated. See CLAUDE.md.
+final class SuggestionService {
+    private let calendar: CalendarDataProvider
+    private let relationshipService: RelationshipService
+    private let strategy: any SuggestionStrategy
+
+    init(
+        calendar: CalendarDataProvider,
+        relationshipService: RelationshipService,
+        strategy: any SuggestionStrategy
+    ) {
+        self.calendar = calendar
+        self.relationshipService = relationshipService
+        self.strategy = strategy
+    }
+
+    /// Returns a Suggestion when both a free slot and an overdue contact exist,
+    /// nil otherwise.
+    func generateSuggestion() async -> Suggestion? {
+        // Signal 1: opportunity. Check first — it's synchronous and cheap.
+        guard let freeSlot = calendar.findFreeSlot() else { return nil }
+
+        // Signal 2: need. Fetch health scores and let the strategy decide.
+        let healthScores = await relationshipService.computeHealth()
+        guard var suggestion = strategy.suggest(from: healthScores) else { return nil }
+
+        // Attach the real free slot. The strategy sets a throwaway proposedTime
+        // because it has no knowledge of calendar availability.
+        suggestion.proposedTime = freeSlot
+        return suggestion
+    }
+}

--- a/Eta/Strategies/RulesSuggestionStrategy.swift
+++ b/Eta/Strategies/RulesSuggestionStrategy.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Selects a hangout suggestion from a ranked list of relationship health scores.
+///
+/// Returns nil when the highest-scoring active contact has a score below
+/// `minimumScoreThreshold` — interpreted as "you've seen everyone recently,
+/// no suggestion needed." This is the demand half of the opportunity-and-demand gate;
+/// SuggestionService handles the opportunity half (free calendar slot).
+///
+/// The `proposedTime` in the returned Suggestion is a throwaway placeholder.
+/// SuggestionService always overwrites it with the actual free slot before returning
+/// to the caller — the strategy has no knowledge of calendar availability.
+final class RulesSuggestionStrategy: SuggestionStrategy {
+
+    /// Contacts with a score below this threshold are considered "recently seen"
+    /// and do not qualify for a suggestion. 7.0 corresponds to roughly one week.
+    private let minimumScoreThreshold: Double = 7
+
+    func suggest(from healthScores: [RelationshipHealth]) -> Suggestion? {
+        guard let top = healthScores
+            .filter({ $0.contact.isActive && $0.score >= minimumScoreThreshold })
+            .max(by: { $0.score < $1.score })
+        else { return nil }
+
+        guard let activity = Activity.allCases.randomElement() else { return nil }
+
+        return Suggestion(
+            contact: top.contact,
+            activity: activity,
+            reason: reason(for: top),
+            proposedTime: DateInterval(start: .now, duration: 3600), // overwritten by SuggestionService
+            generatedAt: .now
+        )
+    }
+
+    // MARK: - Private
+
+    private func reason(for health: RelationshipHealth) -> String {
+        guard let days = health.daysSinceLastHangout else {
+            return "You two haven't hung out yet"
+        }
+        switch days {
+        case 7..<14:
+            return "You haven't hung out in over a week"
+        case 14..<30:
+            return "It's been \(days) days since your last hangout"
+        default:
+            return "You haven't hung out in over a month"
+        }
+    }
+}

--- a/Eta/ViewModels/SuggestionViewModel.swift
+++ b/Eta/ViewModels/SuggestionViewModel.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Drives SuggestionView.
+///
+/// Scene phase is observed in SuggestionView (via @Environment(\.scenePhase)),
+/// not here — keeping this ViewModel free of SwiftUI and UIKit imports.
+/// The View calls refresh() from .onChange(of: scenePhase) when the scene becomes .active.
+@Observable
+final class SuggestionViewModel {
+    private(set) var suggestion: Suggestion?
+    private(set) var isLoading: Bool = false
+
+    private let suggestionService: SuggestionService
+    private let formatter: ContactFormatter
+
+    init(suggestionService: SuggestionService, formatter: ContactFormatter) {
+        self.suggestionService = suggestionService
+        self.formatter = formatter
+    }
+
+    // MARK: - Display
+
+    func displayName(for suggestion: Suggestion) -> String {
+        formatter.displayName(for: suggestion.contact)
+    }
+
+    /// Returns a natural-language description of when the proposed free slot falls,
+    /// e.g. "this afternoon", "tomorrow morning", "Wednesday evening".
+    func timeLabel(for suggestion: Suggestion) -> String {
+        let start = suggestion.proposedTime.start
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: .now)
+        let slotDay = cal.startOfDay(for: start)
+        let dayOffset = cal.dateComponents([.day], from: today, to: slotDay).day ?? 0
+        let hour = cal.component(.hour, from: start)
+
+        let timeOfDay: String
+        switch hour {
+        case 5..<12: timeOfDay = "morning"
+        case 12..<18: timeOfDay = "afternoon"
+        default:     timeOfDay = "evening"
+        }
+
+        switch dayOffset {
+        case 0:  return "this \(timeOfDay)"
+        case 1:  return "tomorrow \(timeOfDay)"
+        default:
+            let df = DateFormatter()
+            df.dateFormat = "EEEE" // e.g. "Wednesday"
+            return "\(df.string(from: start)) \(timeOfDay)"
+        }
+    }
+
+    // MARK: - Actions
+
+    func refresh() async {
+        isLoading = true
+        defer { isLoading = false }
+        suggestion = await suggestionService.generateSuggestion()
+    }
+
+    /// Clears the current suggestion. The inbox will show its empty state until
+    /// the next refresh() call recomputes from scratch.
+    func dismiss() {
+        suggestion = nil
+    }
+}

--- a/Eta/Views/Suggestion/SuggestionCard.swift
+++ b/Eta/Views/Suggestion/SuggestionCard.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// Displays a single opportunity-driven hangout suggestion.
+///
+/// Receives pre-formatted strings from SuggestionViewModel — no ViewModel
+/// reference needed here. The "Yes" button is intentionally disabled in PR 4;
+/// it will be wired to InviteService in PR 5.
+struct SuggestionCard: View {
+    let displayName: String
+    let timeLabel: String
+    let suggestion: Suggestion
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("You have time \(timeLabel) —")
+                    .font(.title2)
+                    .foregroundStyle(.secondary)
+
+                Text("want to \(activityPhrase) with \(displayName)?")
+                    .font(.title)
+                    .fontWeight(.semibold)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            Text(suggestion.reason)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 32)
+
+            VStack(spacing: 12) {
+                Button("Yes, let's do it!") { }
+                    .buttonStyle(.borderedProminent)
+                    .frame(maxWidth: .infinity)
+                    .disabled(true) // wired in PR 5
+
+                Button("Maybe Later", action: onDismiss)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    /// Lowercases the first character of the activity rawValue so it reads as
+    /// natural prose: "want to grab coffee" not "want to Grab coffee".
+    private var activityPhrase: String {
+        let raw = suggestion.activity.rawValue
+        return raw.prefix(1).lowercased() + raw.dropFirst()
+    }
+}

--- a/Eta/Views/Suggestion/SuggestionView.swift
+++ b/Eta/Views/Suggestion/SuggestionView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct SuggestionView: View {
+    let viewModel: SuggestionViewModel
+
+    @Environment(\.scenePhase) private var scenePhase
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.isLoading {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let suggestion = viewModel.suggestion {
+                    SuggestionCard(
+                        displayName: viewModel.displayName(for: suggestion),
+                        timeLabel: viewModel.timeLabel(for: suggestion),
+                        suggestion: suggestion,
+                        onDismiss: { viewModel.dismiss() }
+                    )
+                } else {
+                    ContentUnavailableView(
+                        "Nothing to suggest right now",
+                        systemImage: "calendar.badge.clock",
+                        description: Text("We'll suggest a hangout when you have free time and a friend to catch up with.")
+                    )
+                }
+            }
+            .navigationTitle("For You")
+            .navigationBarTitleDisplayMode(.large)
+            .refreshable {
+                await viewModel.refresh()
+            }
+        }
+        .task {
+            await viewModel.refresh()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                Task { await viewModel.refresh() }
+            }
+        }
+    }
+}

--- a/docs/implementation-schedule.md
+++ b/docs/implementation-schedule.md
@@ -91,6 +91,6 @@ Covers:
 | PR 1 — Scaffold, models, protocols | [x] Complete |
 | PR 2 — Connections                 | [x] Complete    |
 | PR 3 — Calendar + health           | [x] Complete    |
-| PR 4 — Suggestion engine           | [ ] Not started |
+| PR 4 — Suggestion engine           | [x] Complete    |
 | PR 5 — Invite flow                 | [ ] Not started |
 | PR 6 — Hardening                   | [ ] Not started |

--- a/docs/implementation-schedule.md
+++ b/docs/implementation-schedule.md
@@ -46,14 +46,19 @@ Files:
 ---
 
 ## PR 4 — Suggestion engine and For You tab
-**Shippable demo:** For You tab shows real suggestion card, pull-to-refresh works
+**Shippable demo:** For You tab shows an opportunity-driven suggestion card ("You have time this afternoon — want to grab coffee with Karan?"), pull-to-refresh works, inbox is empty when there's no free time or no overdue friend
+
+A suggestion requires **both signals**: a free slot in the near-term calendar AND a contact
+whose health score exceeds the recency threshold (score ≥ 7). Either signal alone → empty inbox.
 
 Files:
-- `Eta/Strategies/RulesSuggestionStrategy.swift` — sort by health score, pick top
-- `Eta/Services/SuggestionService.swift` — RelationshipService + SuggestionStrategy → Suggestion
-- `Eta/ViewModels/SuggestionViewModel.swift` — scene-phase observer, pull-to-refresh
-- `Eta/Views/Suggestion/SuggestionView.swift` — suggestion layout, disabled Send button
-- `Eta/Views/Suggestion/SuggestionCard.swift` — reusable card component
+- `Eta/Models/Suggestion.swift` — add `proposedTime: DateInterval`
+- `Eta/DataProviders/CalendarDataProvider.swift` — add `findFreeSlot(within:minimumDuration:)`, searches up to 3 days ahead in a 9am–9pm window for a gap ≥ 1 hour
+- `Eta/Strategies/RulesSuggestionStrategy.swift` — returns nil if highest score < 7 ("recently saw everyone"); otherwise picks top contact, random activity, tiered reason string
+- `Eta/Services/SuggestionService.swift` — checks free slot first, then health; attaches `proposedTime` to strategy result; depends on `CalendarDataProvider` concretely for slot detection
+- `Eta/ViewModels/SuggestionViewModel.swift` — `@Observable`; exposes `suggestion`, `isLoading`, `timeLabel`; `refresh() async`, `dismiss()`
+- `Eta/Views/Suggestion/SuggestionView.swift` — inbox style; empty state when no suggestion; scene phase observed here via `.onChange(of: scenePhase)`
+- `Eta/Views/Suggestion/SuggestionCard.swift` — displays time label + contact + activity; "Yes" disabled (PR 5); "Maybe Later" calls `dismiss()`
 
 ---
 


### PR DESCRIPTION
**Issues:** #35

## Summary                                                                                                                                                                                                                                             

Now that we have contacts and access to the user's calendar, we can implement a basic activity suggestion engine. For the MVP, this will be a rule-based approach instead of agentic AI.

  Implements suggestion engine + UI. The app can now surface a single, opportunity-driven hangout suggestion — combining a free calendar slot with an overdue friend — and display it as a full-screen card. The "Send Invite" button is present but disabled; it will be wired in future work.
                                                                                                                                                                                                                                                         
  ## Changes                                                                                                                                                                                                                                             
   
  **Models**                                                                                                                                                                                                                                             
  - `Suggestion` — added `proposedTime: DateInterval`, the specific free calendar slot that triggered the suggestion. This field is set by `SuggestionService` after the strategy runs; the strategy itself writes a throwaway placeholder that is always
   overwritten before the suggestion reaches the UI.                                                                                                                                                                                                     
   
  **Data layer**                                                                                                                                                                                                                                         
  - `CalendarDataProvider` — added `findFreeSlot(within:minimumDuration:)`. Searches up to 3 days ahead in a 9am–9pm window, starting from the current time on the current day. Walks sorted busy events and returns the earliest gap ≥ 1 hour, or nil.
  This method lives on the concrete type (not `ImplicitDataProvider`) because free slot detection is a distinct capability from historical event fetching — see CLAUDE.md.                                                                               
   
  **Strategy**                                                                                                                                                                                                                                           
  - `RulesSuggestionStrategy` (new) — filters active contacts to those with `score ≥ 7.0` (approximately one week overdue), picks the highest scorer, selects a random `Activity`, and builds a tiered reason string based on days since last hangout. 
  Returns nil if no contact clears the threshold.                                                                                                                                                                                                        
   
  **Services**                                                                                                                                                                                                                                           
  - `SuggestionService` (new) — checks the free slot first (synchronous and cheap) before computing health scores. If a slot exists, fans out to `RelationshipService` and the strategy, then overwrites the strategy's placeholder `proposedTime` with
  the real slot before returning to the caller. Both signals must be present; either absent returns nil.                                                                                                                                                 
   
  **ViewModel**                                                                                                                                                                                                                                          
  - `SuggestionViewModel` (new) — `@Observable`. Exposes `suggestion`, `isLoading`, `displayName(for:)`, `timeLabel(for:)`, `refresh() async`, and `dismiss()`. `timeLabel` maps the slot's start hour to natural prose ("this afternoon", "tomorrow   
  morning", "Wednesday evening"). No SwiftUI or UIKit imports; scene phase observation is delegated to the View per CLAUDE.md.                                                                                                                           
                                                                                                                                                                                                                                                       
  **Views**                                                                                                                                                                                                                                              
  - `SuggestionView` (new) — shows a `ProgressView` while loading, `SuggestionCard` when a suggestion exists, or `ContentUnavailableView` for the empty inbox. Calls `refresh()` on `.task`, on pull-to-refresh (`.refreshable`), and on scene foreground
   via `.onChange(of: scenePhase)`.                                                                                                                                                                                                                      
  - `SuggestionCard` (new) — renders the time label, activity phrase, contact name, and reason string. "Yes, let's do it!" is rendered but disabled. "Maybe Later" calls `dismiss()` on the ViewModel, clearing the suggestion without persisting
  anything.                                                                                                                                                                                                                                              
  - `MainTabView` — replaced the "Coming Soon" placeholder with `SuggestionView`.                                                                                                                                                                      
                                                                                                                                                                                                                                                         
  **Wiring**                                                                                                                                                                                                                                           
  - `EtaApp` — instantiates `RulesSuggestionStrategy`, `SuggestionService`, and `SuggestionViewModel`. The single `CalendarDataProvider` instance is shared between `RelationshipService` (historical event fetching) and `SuggestionService` (free slot 
  detection), consistent with the dependency graph in CLAUDE.md.                                                                                                                                                                                         
   
  **Cleanup**                                                                                                                                                                                                                                            
  - `RelationshipService` — removed two noisy `print` statements left over from PR 3 development.                                                                                                                                                      
                                                                                                                                                                                                                                                         
  ## Notes
                                                                                                                                                                                                                                                         
  - **"Yes" button is intentionally disabled.** `SuggestionCard` renders the button in its final position so layout is stable, but the action is wired to a no-op. PR 5 adds `iMessageInviteProvider`, `InviteService`, and                              
  `SuggestionViewModel.sendInvite()` to complete the loop.
  - **Dismiss is ephemeral.** Tapping "Maybe Later" sets `suggestion = nil` in memory only. The next `refresh()` (on next foreground or pull-to-refresh) recomputes from scratch and may resurface the same friend if they are still the top scorer and a
   free slot still exists. Suggestion history is explicitly out of scope for MVP.                                                                                                                                                                        
  - **Score threshold is hardcoded.** The `7.0` minimum in `RulesSuggestionStrategy` is a private constant, not configurable. It maps loosely to "not seen in the last week." Adjust here if tuning is needed before the threshold becomes user-facing.
  - **Free slot search is synchronous.** `findFreeSlot` reads from `EKEventStore` on the calling thread. This is fast in practice (in-memory predicate over a small day range) but worth noting if the method is ever extended to larger windows.
