### PR TITLE
[REVIEW] Functional LLM chat interface

### DIFF
--- a/Eta.xcodeproj/xcshareddata/xcschemes/Eta.xcscheme
+++ b/Eta.xcodeproj/xcshareddata/xcschemes/Eta.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2640"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/Eta/App/MainTabView.swift
+++ b/Eta/App/MainTabView.swift
@@ -16,6 +16,7 @@ struct MainTabView: View {
     let weeklyCheckInService: WeeklyCheckInService
     let weeklyCheckInState: WeeklyCheckInState
     let nudgeReminderState: NudgeReminderState
+    let chatViewModel: ChatViewModel
 
     @State private var selectedTab: TabChoice = .events
 
@@ -39,6 +40,12 @@ struct MainTabView: View {
                     analyticsService: analyticsService
                 )
             }
+        }
+        // Floating chat button — pinned above the tab bar in the bottom-trailing corner.
+        .overlay(alignment: .bottomTrailing) {
+            FloatingChatButton(viewModel: chatViewModel)
+                .padding(.trailing, 20)
+                .padding(.bottom, 72) // clears the tab bar (≈49pt) + breathing room
         }
         .analyticsDebug(service: analyticsService)
         .reminderDebug(nudgeService: nudgeService, weeklyCheckInService: weeklyCheckInService)

--- a/Eta/App/MainTabView.swift
+++ b/Eta/App/MainTabView.swift
@@ -25,6 +25,11 @@ struct MainTabView: View {
 
     var body: some View {
         TabView(selection: $selectedTab) {
+            Tab("Availability", systemImage: "clock.badge.checkmark", value: .availability) {
+                AvailabilityView(
+                    viewModel: availabilityViewModel
+                )
+            }
             Tab("Friends", systemImage: "person.2.fill", value: .friends) {
                 ConnectionsView(
                     viewModel: connectionsViewModel,
@@ -32,21 +37,16 @@ struct MainTabView: View {
                     analyticsService: analyticsService
                 )
             }
-            Tab("Availability", systemImage: "clock.badge.checkmark", value: .availability) {
-                AvailabilityView(
-                    viewModel: availabilityViewModel
+            Tab("Events", systemImage: "cup.and.saucer", value: .events) {
+                UpcomingEventsDashboard(
+                    viewModel: upcomingEventsViewModel,
+                    photoRepository: photoRepository
                 )
             }
             Tab("Suggestions", systemImage: "sparkles", value: .suggestions) {
                 SuggestionView(
                     viewModel: suggestionViewModel,
                     analyticsService: analyticsService
-                )
-            }
-            Tab("Events", systemImage: "cup.and.saucer", value: .events) {
-                UpcomingEventsDashboard(
-                    viewModel: upcomingEventsViewModel,
-                    photoRepository: photoRepository
                 )
             }
         }

--- a/Eta/DataProviders/GitHubModelsLLMRunner.swift
+++ b/Eta/DataProviders/GitHubModelsLLMRunner.swift
@@ -2,39 +2,71 @@ import Foundation
 
 /// LLMRunner that calls the GitHub Models inference API (OpenAI-compatible) via URLSession.
 ///
-/// Uses Meta Llama 3.1 8B Instruct — free under the GitHub Models free tier.
 /// API key is a GitHub personal access token read from the app bundle under `LLM_API_KEY`.
 /// Set this in Info.plist referencing a build variable (e.g. via an xcconfig file)
 /// so the key is never checked into source control.
 final class GitHubModelsLLMRunner: LLMRunner {
 
+    enum Model: String {
+        case gpt4oMini  = "gpt-4o-mini"
+        case llama31_8b = "meta-llama-3.1-8b-instruct"
+    }
+
+    private let model: Model
+
+    init(model: Model = .gpt4oMini) {
+        self.model = model
+    }
+
+    // MARK: — LLMRunner
+
+    func generate(systemPrompt: String, userPrompt: String) async throws -> String {
+        try await execute(apiMessages: [
+            .init(role: "system", content: systemPrompt),
+            .init(role: "user",   content: userPrompt)
+        ])
+    }
+
+    /// Overrides the default transcript fallback with proper multi-turn role separation.
+    func generate(messages: [LLMMessage]) async throws -> String {
+        let apiMessages = messages.map { msg -> APIMessage in
+            let role: String = switch msg.role {
+            case .system:    "system"
+            case .user:      "user"
+            case .assistant: "assistant"
+            }
+            return APIMessage(role: role, content: msg.content)
+        }
+        return try await execute(apiMessages: apiMessages, maxTokens: 128)
+    }
+
+    // MARK: — Private
+
     private struct RequestBody: Encodable {
         let model: String
         let max_tokens: Int
-        let messages: [Message]
+        let messages: [APIMessage]
+    }
 
-        struct Message: Encodable {
-            let role: String
-            let content: String
-        }
+    private struct APIMessage: Encodable {
+        let role: String
+        let content: String
     }
 
     private struct ResponseBody: Decodable {
         let choices: [Choice]
-
         struct Choice: Decodable {
             let message: Message
-
             struct Message: Decodable {
                 let content: String
             }
         }
     }
 
-    func generate(systemPrompt: String, userPrompt: String) async throws -> String {
+    private func execute(apiMessages: [APIMessage], maxTokens: Int = 64) async throws -> String {
         guard let apiKey = Bundle.main.object(forInfoDictionaryKey: "LLM_API_KEY") as? String,
               !apiKey.isEmpty else {
-            return Activity.allCases.randomElement()?.description ?? "Grab coffee"
+            throw LLMError.noAPIKey
         }
 
         let url = URL(string: "https://models.inference.ai.azure.com/chat/completions")!
@@ -43,44 +75,34 @@ final class GitHubModelsLLMRunner: LLMRunner {
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        let body = RequestBody(
-            model: "meta-llama-3.1-8b-instruct",
-            max_tokens: 64,
-            messages: [
-                .init(role: "system", content: systemPrompt),
-                .init(role: "user", content: userPrompt)
-            ]
-        )
+        let body = RequestBody(model: model.rawValue, max_tokens: maxTokens, messages: apiMessages)
         request.httpBody = try JSONEncoder().encode(body)
 
-        do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await URLSession.shared.data(for: request)
 
-            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
-                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-                throw LLMError.httpError(statusCode)
-            }
-
-            let decoded = try JSONDecoder().decode(ResponseBody.self, from: data)
-            guard let text = decoded.choices.first?.message.content else {
-                throw LLMError.emptyResponse
-            }
-
-            print("[GitHubLLMRunner] \(body.model) suggested: \(text)")
-            return text
-        } catch {
-            print("[GitHubLLMRunner] falling back to enum: \(error.localizedDescription)")
-            return Activity.allCases.randomElement()?.description ?? "Grab coffee"
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw LLMError.httpError(code)
         }
+
+        let decoded = try JSONDecoder().decode(ResponseBody.self, from: data)
+        guard let text = decoded.choices.first?.message.content else {
+            throw LLMError.emptyResponse
+        }
+
+        print("[GitHubLLMRunner] \(model.rawValue): \(text)")
+        return text
     }
 }
 
 private enum LLMError: LocalizedError {
+    case noAPIKey
     case httpError(Int)
     case emptyResponse
 
     var errorDescription: String? {
         switch self {
+        case .noAPIKey:           return "LLM_API_KEY is missing or empty in Info.plist."
         case .httpError(let code): return "GitHub Models API returned HTTP \(code)."
         case .emptyResponse:      return "GitHub Models API returned no text content."
         }

--- a/Eta/EtaApp.swift
+++ b/Eta/EtaApp.swift
@@ -25,6 +25,7 @@ struct EtaApp: App {
     private let weeklyCheckInService: WeeklyCheckInService
     private let weeklyCheckInState: WeeklyCheckInState
     private let nudgeReminderState: NudgeReminderState
+    private let chatViewModel: ChatViewModel
     @State private var onboardingViewModel: OnboardingViewModel
 
     init() {
@@ -100,11 +101,13 @@ struct EtaApp: App {
         UNUserNotificationCenter.current().delegate = notificationDelegate
         self.notificationDelegate = notificationDelegate
 
-        self.connectionsViewModel = ConnectionsViewModel(
+        let connectionsViewModel = ConnectionsViewModel(
             repository: repository,
             formatter: formatter,
             relationshipService: relationshipService
         )
+        self.connectionsViewModel = connectionsViewModel
+        self.chatViewModel = ChatViewModel(connectionsViewModel: connectionsViewModel)
         self.suggestionViewModel = SuggestionViewModel(
             suggestionService: suggestionService,
             inviteService: inviteService,
@@ -136,7 +139,8 @@ struct EtaApp: App {
                     nudgeScheduler: nudgeScheduler,
                     weeklyCheckInService: weeklyCheckInService,
                     weeklyCheckInState: weeklyCheckInState,
-                    nudgeReminderState: nudgeReminderState
+                    nudgeReminderState: nudgeReminderState,
+                    chatViewModel: chatViewModel
                 )
             } else {
                 OnboardingView(viewModel: onboardingViewModel)

--- a/Eta/EtaApp.swift
+++ b/Eta/EtaApp.swift
@@ -144,7 +144,13 @@ struct EtaApp: App {
             formatter: formatter,
             relationshipService: relationshipService
         )
-        self.chatViewModel = ChatViewModel(connectionsViewModel: connectionsViewModel)
+        self.chatViewModel = ChatViewModel(
+            contactRepository: repository,
+            inviteService: inviteService,
+            invitationManager: invitationManager,
+            availabilityDataProvider: availabilityDataProvider,
+            goalRepository: goalRepository
+        )
         self.suggestionViewModel = SuggestionViewModel(
             suggestionService: suggestionService,
             inviteService: inviteService,

--- a/Eta/Models/ChatMessage.swift
+++ b/Eta/Models/ChatMessage.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+struct ChatMessage: Identifiable {
+    enum Role {
+        case user
+        case assistant
+    }
+
+    let id = UUID()
+    let role: Role
+    let content: String
+    /// Set when the assistant's response contains a parsed function call.
+    var functionCall: ChatFunctionCall? = nil
+}
+
+/// Tab the app should navigate to after a chat action completes.
+/// MainTabView maps these to its internal TabChoice.
+enum ChatNavigation {
+    case events
+    case suggestions
+}
+
+/// Structured actions the LLM can invoke once it has gathered enough context.
+enum ChatFunctionCall: Equatable {
+    case scheduleHangout(friendName: String, activity: String, proposedTime: String)
+    case reflectOnTrends(period: String)
+    case setGoal(friendName: String, goal: String)
+    case provideFeedback(friendName: String, activity: String, sentiment: String)
+
+    var displayLabel: String {
+        switch self {
+        case .scheduleHangout(let name, let activity, let time):
+            return "Schedule \(activity) with \(name) · \(time)"
+        case .reflectOnTrends(let period):
+            return "Reflect on \(period)"
+        case .setGoal(let name, let goal):
+            return "Set goal for \(name): \(goal)"
+        case .provideFeedback(let name, let activity, _):
+            return "Log feedback for \(activity) with \(name)"
+        }
+    }
+
+    var systemImageName: String {
+        switch self {
+        case .scheduleHangout:  return "calendar.badge.plus"
+        case .reflectOnTrends:  return "chart.bar"
+        case .setGoal:          return "target"
+        case .provideFeedback:  return "hand.thumbsup"
+        }
+    }
+}

--- a/Eta/Models/ChatMessage.swift
+++ b/Eta/Models/ChatMessage.swift
@@ -23,29 +23,21 @@ enum ChatNavigation {
 /// Structured actions the LLM can invoke once it has gathered enough context.
 enum ChatFunctionCall: Equatable {
     case scheduleHangout(friendName: String, activity: String, proposedTime: String)
-    case reflectOnTrends(period: String)
     case setGoal(friendName: String, goal: String)
-    case provideFeedback(friendName: String, activity: String, sentiment: String)
 
     var displayLabel: String {
         switch self {
         case .scheduleHangout(let name, let activity, let time):
             return "Schedule \(activity) with \(name) · \(time)"
-        case .reflectOnTrends(let period):
-            return "Reflect on \(period)"
         case .setGoal(let name, let goal):
             return "Set goal for \(name): \(goal)"
-        case .provideFeedback(let name, let activity, _):
-            return "Log feedback for \(activity) with \(name)"
         }
     }
 
     var systemImageName: String {
         switch self {
-        case .scheduleHangout:  return "calendar.badge.plus"
-        case .reflectOnTrends:  return "chart.bar"
-        case .setGoal:          return "target"
-        case .provideFeedback:  return "hand.thumbsup"
+        case .scheduleHangout: return "calendar.badge.plus"
+        case .setGoal:         return "target"
         }
     }
 }

--- a/Eta/Protocols/LLMRunner.swift
+++ b/Eta/Protocols/LLMRunner.swift
@@ -1,15 +1,38 @@
 import Foundation
 
+/// A single message in an LLM conversation.
+struct LLMMessage {
+    enum Role { case system, user, assistant }
+    let role: Role
+    let content: String
+}
+
 /// Executes a prompt against a language model and returns the raw text response.
 ///
 /// This protocol is intentionally thin — it knows nothing about suggestions,
 /// contacts, or activities. Prompt construction and response parsing are
-/// the responsibility of the caller (LLMActivityStrategy).
+/// the responsibility of the caller (LLMActivityStrategy, ChatService, etc.).
 ///
-/// Today: StubLLMRunner (returns hardcoded text for development/testing).
-/// Tomorrow: SpeziLLMRunner (on-device) or a remote API conformer.
+/// Today: GitHubModelsLLMRunner (remote API).
+/// Tomorrow: SpeziLLMRunner (on-device) or any other conformer.
 /// Swap implementations in EtaApp.swift without touching any strategy code.
 protocol LLMRunner {
-    /// Sends the given prompt to the underlying model and returns the raw response string.
+    /// Single-turn convenience: system prompt + one user message.
     func generate(systemPrompt: String, userPrompt: String) async throws -> String
+
+    /// Multi-turn: full message history including system, user, and assistant turns.
+    /// Default implementation serialises the history as a transcript and delegates
+    /// to the single-turn method — conformers can override for native multi-turn support.
+    func generate(messages: [LLMMessage]) async throws -> String
+}
+
+extension LLMRunner {
+    func generate(messages: [LLMMessage]) async throws -> String {
+        let system = messages.first { $0.role == .system }?.content ?? ""
+        let transcript = messages
+            .filter { $0.role != .system }
+            .map { ($0.role == .user ? "User" : "Assistant") + ": " + $0.content }
+            .joined(separator: "\n")
+        return try await generate(systemPrompt: system, userPrompt: transcript)
+    }
 }

--- a/Eta/Services/ChatService.swift
+++ b/Eta/Services/ChatService.swift
@@ -70,19 +70,10 @@ final class ChatService {
                   let time     = args["proposedTime"] else { return nil }
             return .scheduleHangout(friendName: friend, activity: activity, proposedTime: time)
 
-        case "reflectOnTrends":
-            return .reflectOnTrends(period: args["period"] ?? "recent")
-
         case "setGoal":
             guard let friend = args["friendName"],
                   let goal   = args["goal"] else { return nil }
             return .setGoal(friendName: friend, goal: goal)
-
-        case "provideFeedback":
-            guard let friend    = args["friendName"],
-                  let activity  = args["activity"],
-                  let sentiment = args["sentiment"] else { return nil }
-            return .provideFeedback(friendName: friend, activity: activity, sentiment: sentiment)
 
         default:
             return nil

--- a/Eta/Services/ChatService.swift
+++ b/Eta/Services/ChatService.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Manages a multi-turn LLM conversation for the in-app chat interface.
+///
+/// Converts the app's ChatMessage history into LLMMessages and delegates to any LLMRunner.
+/// Function call detection uses a `<<FUNCTION_CALL>>…<</FUNCTION_CALL>>` block
+/// that the model is prompted to emit once it has all required arguments.
+final class ChatService {
+
+    private let runner: any LLMRunner
+    private let systemPrompt: String
+
+    init(systemPrompt: String, runner: any LLMRunner = GitHubModelsLLMRunner()) {
+        self.systemPrompt = systemPrompt
+        self.runner = runner
+    }
+
+    // MARK: — Send
+
+    /// Sends the full conversation history and returns the model's reply plus any parsed function call.
+    func send(messages: [ChatMessage]) async -> (reply: String, functionCall: ChatFunctionCall?) {
+        var llmMessages: [LLMMessage] = [.init(role: .system, content: systemPrompt)]
+        llmMessages += messages.map { msg in
+            .init(role: msg.role == .user ? .user : .assistant, content: msg.content)
+        }
+
+        let raw: String
+        do {
+            raw = try await runner.generate(messages: llmMessages)
+        } catch {
+            print("[ChatService] runner error: \(error)")
+            return ("Something went wrong. Try again?", nil)
+        }
+
+        return parseFunctionCall(from: raw)
+    }
+
+    // MARK: — Function call parsing
+
+    private func parseFunctionCall(from text: String) -> (String, ChatFunctionCall?) {
+        let open  = "<<FUNCTION_CALL>>"
+        let close = "<</FUNCTION_CALL>>"
+
+        guard let startRange = text.range(of: open),
+              let endRange   = text.range(of: close),
+              startRange.upperBound <= endRange.lowerBound else {
+            return (text.trimmingCharacters(in: .whitespacesAndNewlines), nil)
+        }
+
+        let jsonString = String(text[startRange.upperBound..<endRange.lowerBound])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let humanText  = String(text[..<startRange.lowerBound])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let call = decodeCall(jsonString)
+        print("[ChatService] Function call: \(jsonString)")
+        return (humanText.isEmpty ? "Got it — ready to go!" : humanText, call)
+    }
+
+    private func decodeCall(_ json: String) -> ChatFunctionCall? {
+        guard let data = json.data(using: .utf8),
+              let obj  = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let fn   = obj["function"] as? String,
+              let args = obj["args"] as? [String: String] else { return nil }
+
+        switch fn {
+        case "scheduleHangout":
+            guard let friend   = args["friendName"],
+                  let activity = args["activity"],
+                  let time     = args["proposedTime"] else { return nil }
+            return .scheduleHangout(friendName: friend, activity: activity, proposedTime: time)
+
+        case "reflectOnTrends":
+            return .reflectOnTrends(period: args["period"] ?? "recent")
+
+        case "setGoal":
+            guard let friend = args["friendName"],
+                  let goal   = args["goal"] else { return nil }
+            return .setGoal(friendName: friend, goal: goal)
+
+        case "provideFeedback":
+            guard let friend    = args["friendName"],
+                  let activity  = args["activity"],
+                  let sentiment = args["sentiment"] else { return nil }
+            return .provideFeedback(friendName: friend, activity: activity, sentiment: sentiment)
+
+        default:
+            return nil
+        }
+    }
+}

--- a/Eta/Services/NudgeService.swift
+++ b/Eta/Services/NudgeService.swift
@@ -175,8 +175,7 @@ final class NudgeService {
     }
 
     /// Asks the runner to suggest an activity phrase using the same prompt as LLMActivityStrategy.
-    /// With an API key: returns a free-form LLM phrase.
-    /// Without an API key: runner falls back to a random Activity rawValue — one code path for both.
+    /// On any runner error (no API key, network failure, etc.) falls back to a random Activity rawValue.
     /// Pass nil health for the no-friend case (generic prompt).
     private func suggestActivity(for health: RelationshipHealth?) async -> String {
         let system = """

--- a/Eta/Strategies/LLMActivityStrategy.swift
+++ b/Eta/Strategies/LLMActivityStrategy.swift
@@ -44,7 +44,17 @@ final class LLMActivityStrategy: ActivityStrategy {
         Suggest one new activity for them to do together not previously seen.
         """
 
-        let raw = try await runner.generate(systemPrompt: systemPrompt, userPrompt: userPrompt)
+        let raw: String
+        do {
+            raw = try await runner.generate(systemPrompt: systemPrompt, userPrompt: userPrompt)
+        } catch {
+            // Fallback to a random Activity on any runner error (no key, network, rate limit, etc.).
+            // Future: propagate the error and let SuggestionService decide whether to degrade
+            // to RulesActivityStrategy or surface the failure to the ViewModel.
+            print("[LLMActivityStrategy] runner error — falling back to random activity: \(error.localizedDescription)")
+            let description = Activity.allCases.randomElement()?.description ?? Activity.coffee.description
+            return ActivityProposal(activityDescription: description, reason: reason(for: health))
+        }
         let activityDescription = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !activityDescription.isEmpty else { return nil }
 

--- a/Eta/ViewModels/ChatViewModel.swift
+++ b/Eta/ViewModels/ChatViewModel.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Drives the in-app LLM chat interface.
+///
+/// Builds a context-aware system prompt from the current contact list and health scores,
+/// then manages a multi-turn conversation via ChatService.
+/// Once the model identifies an intent and emits a function call, the ViewModel exposes
+/// it as `pendingFunctionCall` for the View to confirm and invoke.
+@Observable
+final class ChatViewModel {
+
+    private(set) var messages: [ChatMessage] = []
+    private(set) var isSending = false
+    private(set) var pendingFunctionCall: ChatFunctionCall?
+
+    // Set after the user confirms a pending function call.
+    private(set) var invokedAction: ChatFunctionCall?
+
+    private let connectionsViewModel: ConnectionsViewModel
+    /// Lazily built on first send so it captures current contact + health data.
+    private var chatService: ChatService?
+
+    init(connectionsViewModel: ConnectionsViewModel) {
+        self.connectionsViewModel = connectionsViewModel
+    }
+
+    // MARK: — Conversation
+
+    func send(_ text: String) async {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isSending else { return }
+
+        if chatService == nil {
+            chatService = ChatService(systemPrompt: buildSystemPrompt())
+        }
+
+        let userMessage = ChatMessage(role: .user, content: trimmed)
+        messages.append(userMessage)
+        isSending = true
+
+        let (reply, call) = await chatService!.send(messages: messages)
+
+        let assistantMessage = ChatMessage(role: .assistant, content: reply, functionCall: call)
+        messages.append(assistantMessage)
+        if let call { pendingFunctionCall = call }
+        isSending = false
+    }
+
+    /// Called when the user taps the confirm button on a pending function call.
+    /// The body of each case is intentionally left empty — implementation comes later.
+    func invokeAction(_ call: ChatFunctionCall) {
+        switch call {
+        case .scheduleHangout:
+            break
+        case .reflectOnTrends:
+            break
+        case .setGoal:
+            break
+        case .provideFeedback:
+            break
+        }
+        invokedAction = call
+        pendingFunctionCall = nil
+    }
+
+    /// Clears the session so the next chat open starts fresh.
+    func reset() {
+        messages = []
+        pendingFunctionCall = nil
+        invokedAction = nil
+        chatService = nil
+    }
+
+    // MARK: — System prompt
+
+    private func buildSystemPrompt() -> String {
+        let contacts = connectionsViewModel.contacts
+        let healthScores = connectionsViewModel.healthScores
+
+        let friendList: String = contacts.isEmpty ? "none" : contacts.map { contact in
+            let name = "\(contact.givenName) \(contact.familyName)".trimmingCharacters(in: .whitespaces)
+            let days = healthScores[contact.id]?.daysSinceLastHangout.map { "\($0)d ago" } ?? "never seen"
+            return "\(name) (\(days))"
+        }.joined(separator: ", ")
+
+        return """
+        You are Eta, a concise assistant in a friendship app. When the user says what they want, invoke the right function immediately. Fill in any missing details with a reasonable guess — do not ask for them.
+
+        Functions:
+          scheduleHangout(friendName, activity, proposedTime)
+          reflectOnTrends(period)
+          setGoal(friendName, goal)
+          provideFeedback(friendName, activity, sentiment: positive|negative|neutral)
+
+        Format: one short sentence confirming the action, then on the very next line:
+        <<FUNCTION_CALL>>{"function":"<name>","args":{"key":"value"}}<</FUNCTION_CALL>>
+
+        Example:
+        User: Schedule dinner with Johnny somewhere nice
+        Assistant: I'll book a nice Italian dinner with Johnny for Friday at 7pm!
+        <<FUNCTION_CALL>>{"function":"scheduleHangout","args":{"friendName":"Johnny","activity":"Italian dinner","proposedTime":"Friday at 7pm"}}<</FUNCTION_CALL>>
+
+        Only ask a clarifying question if the user's intent is genuinely ambiguous (e.g. two friends with the same name). Otherwise act immediately.
+
+        Friends: \(friendList)
+        """
+    }
+}

--- a/Eta/ViewModels/ChatViewModel.swift
+++ b/Eta/ViewModels/ChatViewModel.swift
@@ -12,16 +12,31 @@ final class ChatViewModel {
     private(set) var messages: [ChatMessage] = []
     private(set) var isSending = false
     private(set) var pendingFunctionCall: ChatFunctionCall?
-
-    // Set after the user confirms a pending function call.
     private(set) var invokedAction: ChatFunctionCall?
+    /// Set to true after an action completes. The presenting view should dismiss when this fires.
+    private(set) var shouldDismiss = false
 
-    private let connectionsViewModel: ConnectionsViewModel
+    private let contactRepository: ContactRepository
+    private let inviteService: InviteService
+    private let invitationManager: InvitationManager
+    private let availabilityDataProvider: AvailabilityDataProvider
+    private let goalRepository: GoalRepository
+
     /// Lazily built on first send so it captures current contact + health data.
     private var chatService: ChatService?
 
-    init(connectionsViewModel: ConnectionsViewModel) {
-        self.connectionsViewModel = connectionsViewModel
+    init(
+        contactRepository: ContactRepository,
+        inviteService: InviteService,
+        invitationManager: InvitationManager,
+        availabilityDataProvider: AvailabilityDataProvider,
+        goalRepository: GoalRepository
+    ) {
+        self.contactRepository = contactRepository
+        self.inviteService = inviteService
+        self.invitationManager = invitationManager
+        self.availabilityDataProvider = availabilityDataProvider
+        self.goalRepository = goalRepository
     }
 
     // MARK: — Conversation
@@ -47,17 +62,12 @@ final class ChatViewModel {
     }
 
     /// Called when the user taps the confirm button on a pending function call.
-    /// The body of each case is intentionally left empty — implementation comes later.
     func invokeAction(_ call: ChatFunctionCall) {
         switch call {
-        case .scheduleHangout:
-            break
-        case .reflectOnTrends:
-            break
-        case .setGoal:
-            break
-        case .provideFeedback:
-            break
+        case .scheduleHangout(let friendName, let activity, let proposedTime):
+            scheduleHangout(friendName: friendName, activity: activity, proposedTimeString: proposedTime)
+        case .setGoal(let friendName, let goal):
+            setGoal(friendName: friendName, goal: goal)
         }
         invokedAction = call
         pendingFunctionCall = nil
@@ -69,38 +79,119 @@ final class ChatViewModel {
         pendingFunctionCall = nil
         invokedAction = nil
         chatService = nil
+        shouldDismiss = false
+    }
+
+    // MARK: — Private actions
+
+    private func scheduleHangout(friendName: String, activity: String, proposedTimeString: String) {
+        guard let contact = resolveContact(named: friendName) else { return }
+
+        Task { @MainActor in
+            let interval: DateInterval
+            if let parsed = parseDate(from: proposedTimeString) {
+                interval = DateInterval(start: parsed, duration: 3600)
+            } else if let slots = try? await availabilityDataProvider.findAvailableSlots(),
+                      let first = slots.first {
+                interval = first
+            } else {
+                return
+            }
+
+            let suggestion = Suggestion(
+                contact: contact,
+                activityDescription: activity,
+                reason: "Scheduled via chat",
+                proposedTimes: [interval],
+                generatedAt: .now
+            )
+            let hangoutID = inviteService.book(suggestion: suggestion)
+            _ = try? await invitationManager.acceptSuggestion(
+                activityName: activity,
+                friendName: friendName,
+                scheduledTime: interval.start,
+                endDate: interval.end,
+                hangoutID: hangoutID
+            )
+            shouldDismiss = true
+        }
+    }
+
+    private func setGoal(friendName: String, goal: String) {
+        guard let contact = resolveContact(named: friendName) else { return }
+        let now = Date()
+        let cadence = GoalCadence.monthly
+        let windowEnd = Calendar.current.date(
+            byAdding: .day, value: cadence.durationInDays, to: now
+        ) ?? now
+        let newGoal = Goal(
+            title: goal,
+            friendIDs: [contact.id],
+            cadence: cadence,
+            target: 2,
+            windowStart: now,
+            windowEnd: windowEnd,
+            source: .aiAccepted
+        )
+        try? goalRepository.add(newGoal)
+        shouldDismiss = true
+    }
+
+    // MARK: — Helpers
+
+    /// Case-insensitive match on given name, full name, or stored display name.
+    /// Fetches directly from the repository so the result is always up-to-date.
+    private func resolveContact(named name: String) -> TrackedContact? {
+        let contacts = (try? contactRepository.fetchAll()) ?? []
+        let lower = name.lowercased()
+        return contacts.first {
+            $0.givenName.lowercased() == lower
+            || "\($0.givenName) \($0.familyName)".lowercased() == lower
+            || $0.name.lowercased().contains(lower)
+        }
+    }
+
+    /// Extracts the first concrete date from a natural-language string using NSDataDetector.
+    private func parseDate(from string: String) -> Date? {
+        guard let detector = try? NSDataDetector(
+            types: NSTextCheckingResult.CheckingType.date.rawValue
+        ) else { return nil }
+        let range = NSRange(string.startIndex..., in: string)
+        return detector.firstMatch(in: string, options: [], range: range)?.date
     }
 
     // MARK: — System prompt
 
     private func buildSystemPrompt() -> String {
-        let contacts = connectionsViewModel.contacts
-        let healthScores = connectionsViewModel.healthScores
+        let contacts = (try? contactRepository.fetchAll()) ?? []
 
         let friendList: String = contacts.isEmpty ? "none" : contacts.map { contact in
-            let name = "\(contact.givenName) \(contact.familyName)".trimmingCharacters(in: .whitespaces)
-            let days = healthScores[contact.id]?.daysSinceLastHangout.map { "\($0)d ago" } ?? "never seen"
-            return "\(name) (\(days))"
+            "\(contact.givenName) \(contact.familyName)".trimmingCharacters(in: .whitespaces)
         }.joined(separator: ", ")
 
         return """
-        You are Eta, a concise assistant in a friendship app. When the user says what they want, invoke the right function immediately. Fill in any missing details with a reasonable guess — do not ask for them.
+        You are Eta, a concise assistant in a friendship app.
 
-        Functions:
+        You can invoke two functions:
           scheduleHangout(friendName, activity, proposedTime)
-          reflectOnTrends(period)
           setGoal(friendName, goal)
-          provideFeedback(friendName, activity, sentiment: positive|negative|neutral)
 
-        Format: one short sentence confirming the action, then on the very next line:
+        Rules:
+        - friendName must exactly match one of the friends listed below. If the user's phrasing is ambiguous or doesn't clearly map to one name, ask one short clarifying question before calling the function.
+        - Fill in all other missing details (activity, time, goal wording) with a reasonable guess — don't ask about them.
+        - Resolve the intent within 1–3 messages. Prefer acting immediately when the friend is unambiguous.
+
+        When you are ready to act, respond with one short confirming sentence followed immediately by the function call on the next line:
         <<FUNCTION_CALL>>{"function":"<name>","args":{"key":"value"}}<</FUNCTION_CALL>>
 
-        Example:
-        User: Schedule dinner with Johnny somewhere nice
-        Assistant: I'll book a nice Italian dinner with Johnny for Friday at 7pm!
-        <<FUNCTION_CALL>>{"function":"scheduleHangout","args":{"friendName":"Johnny","activity":"Italian dinner","proposedTime":"Friday at 7pm"}}<</FUNCTION_CALL>>
+        Example (unambiguous):
+        User: Schedule dinner with Sarah
+        Assistant: I'll book dinner with Sarah for this Friday at 7pm!
+        <<FUNCTION_CALL>>{"function":"scheduleHangout","args":{"friendName":"Sarah Johnson","activity":"Dinner","proposedTime":"this Friday at 7pm"}}<</FUNCTION_CALL>>
 
-        Only ask a clarifying question if the user's intent is genuinely ambiguous (e.g. two friends with the same name). Otherwise act immediately.
+        Example (ambiguous name):
+        User: Schedule something with Alex
+        Assistant: I see two Alexes — Alex Chen or Alex Rivera. Which one did you mean?
 
         Friends: \(friendList)
         """

--- a/Eta/Views/Chat/ChatView.swift
+++ b/Eta/Views/Chat/ChatView.swift
@@ -91,7 +91,7 @@ struct ChatView: View {
             VStack(spacing: 6) {
                 Text("What can I help with?")
                     .font(.headline)
-                Text("Schedule a hangout, reflect on trends,\nset a goal, or log feedback.")
+                Text("Schedule a hangout, reflect on trends,\nor set a goal.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)

--- a/Eta/Views/Chat/ChatView.swift
+++ b/Eta/Views/Chat/ChatView.swift
@@ -1,0 +1,238 @@
+import SwiftUI
+
+/// Full chat UI — message list, typing indicator, text input, and action confirmation banner.
+struct ChatView: View {
+    let viewModel: ChatViewModel
+    @State private var inputText = ""
+    @FocusState private var inputFocused: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                messageList
+                    .animation(.default, value: viewModel.messages.count)
+                    .animation(.default, value: viewModel.isSending)
+
+                if let call = viewModel.pendingFunctionCall {
+                    actionBanner(call)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .animation(.spring(response: 0.35), value: viewModel.pendingFunctionCall != nil)
+                }
+
+                inputBar
+            }
+            .navigationTitle("Eta")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        viewModel.reset()
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: — Message list
+
+    private var messageList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 12) {
+                    if viewModel.messages.isEmpty {
+                        emptyState
+                            .padding(.top, 60)
+                    }
+
+                    ForEach(viewModel.messages) { message in
+                        MessageBubble(message: message)
+                            .id(message.id)
+                    }
+
+                    if viewModel.isSending {
+                        TypingIndicator()
+                            .id("typing")
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            }
+            .onChange(of: viewModel.messages.count) { _, _ in scrollToBottom(proxy: proxy) }
+            .onChange(of: viewModel.isSending)      { _, _ in scrollToBottom(proxy: proxy) }
+        }
+    }
+
+    private func scrollToBottom(proxy: ScrollViewProxy) {
+        withAnimation {
+            if viewModel.isSending {
+                proxy.scrollTo("typing", anchor: .bottom)
+            } else if let last = viewModel.messages.last {
+                proxy.scrollTo(last.id, anchor: .bottom)
+            }
+        }
+    }
+
+    // MARK: — Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(.system(size: 44))
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: 6) {
+                Text("What can I help with?")
+                    .font(.headline)
+                Text("Schedule a hangout, reflect on trends,\nset a goal, or log feedback.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+    }
+
+    // MARK: — Action banner
+
+    private func actionBanner(_ call: ChatFunctionCall) -> some View {
+        HStack(spacing: 12) {
+            // Icon on accent background — force dark scheme so .primary resolves to light.
+            Image(systemName: call.systemImageName)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(.primary)
+                .frame(width: 36, height: 36)
+                .background(Color.accentColor, in: Circle())
+                .environment(\.colorScheme, .dark)
+
+            Text(call.displayLabel)
+                .font(.subheadline.weight(.medium))
+                .lineLimit(2)
+
+            Spacer()
+
+            Button("Confirm") {
+                viewModel.invokeAction(call)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.regularMaterial)
+        .overlay(alignment: .top) { Divider() }
+    }
+
+    // MARK: — Input bar
+
+    private var inputBar: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            TextField("Message", text: $inputText, axis: .vertical)
+                .textFieldStyle(.plain)
+                .lineLimit(1...5)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20))
+                .focused($inputFocused)
+                .onSubmit { sendIfNeeded() }
+                .disabled(viewModel.isSending)
+
+            Button {
+                sendIfNeeded()
+            } label: {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 32))
+                    .foregroundStyle(canSend ? Color.accentColor : Color.secondary)
+            }
+            .disabled(!canSend)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(.bar)
+        .overlay(alignment: .top) { Divider() }
+    }
+
+    private var canSend: Bool {
+        !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !viewModel.isSending
+    }
+
+    private func sendIfNeeded() {
+        guard canSend else { return }
+        let text = inputText
+        inputText = ""
+        Task { await viewModel.send(text) }
+    }
+}
+
+// MARK: — MessageBubble
+
+private struct MessageBubble: View {
+    let message: ChatMessage
+
+    var isUser: Bool { message.role == .user }
+
+    var body: some View {
+        HStack {
+            if isUser { Spacer(minLength: 60) }
+            bubble
+            if !isUser { Spacer(minLength: 60) }
+        }
+    }
+
+    /// Separate branches so that `.environment(\.colorScheme, .dark)` is applied only
+    /// to user bubbles — assistant bubbles adapt to the system color scheme naturally.
+    @ViewBuilder
+    private var bubble: some View {
+        if isUser {
+            Text(message.content)
+                .font(.body)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .foregroundStyle(.primary)
+                .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 18))
+                // Force dark scheme inside the accent-colored bubble so .primary
+                // resolves to its light (accessible) variant.
+                .environment(\.colorScheme, .dark)
+        } else {
+            Text(message.content)
+                .font(.body)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .foregroundStyle(.primary)
+                .background(Color.primary.opacity(0.08), in: RoundedRectangle(cornerRadius: 18))
+        }
+    }
+}
+
+// MARK: — TypingIndicator
+
+private struct TypingIndicator: View {
+    @State private var animating = false
+
+    var body: some View {
+        HStack {
+            HStack(spacing: 4) {
+                ForEach(0..<3) { i in
+                    Circle()
+                        .frame(width: 7, height: 7)
+                        .foregroundStyle(.secondary)
+                        .scaleEffect(animating ? 1.0 : 0.6)
+                        .opacity(animating ? 1.0 : 0.4)
+                        .animation(
+                            .easeInOut(duration: 0.5)
+                                .repeatForever(autoreverses: true)
+                                .delay(Double(i) * 0.15),
+                            value: animating
+                        )
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(Color.primary.opacity(0.08), in: RoundedRectangle(cornerRadius: 18))
+
+            Spacer(minLength: 60)
+        }
+        .onAppear { animating = true }
+        .onDisappear { animating = false }
+    }
+}

--- a/Eta/Views/Chat/ChatView.swift
+++ b/Eta/Views/Chat/ChatView.swift
@@ -32,6 +32,12 @@ struct ChatView: View {
                     }
                 }
             }
+            .onChange(of: viewModel.shouldDismiss) { _, shouldDismiss in
+                if shouldDismiss {
+                    viewModel.reset()
+                    dismiss()
+                }
+            }
         }
     }
 

--- a/Eta/Views/Chat/FloatingChatButton.swift
+++ b/Eta/Views/Chat/FloatingChatButton.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Floating Action Button that presents the LLM chat interface as a sheet.
+///
+/// Pin this above the tab bar using `.overlay(alignment: .bottomTrailing)` on the TabView.
+struct FloatingChatButton: View {
+    let viewModel: ChatViewModel
+    @State private var isPresented = false
+
+    var body: some View {
+        Button {
+            isPresented = true
+        } label: {
+            Image(systemName: "bubble.left.and.text.bubble.right.fill")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 56, height: 56)
+                .background(Color.accentColor, in: Circle())
+                .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
+        }
+        .sheet(isPresented: $isPresented, onDismiss: { viewModel.reset() }) {
+            ChatView(viewModel: viewModel)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Issues:** #57 

Easily set goals, schedule hangouts, and reflect on trends with a focused LLM-powered chat interface. The UX is designed around a focused, task-oriented interaction where the LLM is explicitly prompted to gather the necessary information to invoke one of a discrete set of pre-defined tools (e.g. `scheduleHangout` or `setGoal`).

## Changes

- Added a pinned button overlaying the bottom trailing corner of the screen. On tap, a half-sheet appears where the user can have a text conversation with an LLM agent.
- The LLM's messages can be translated to explicit function calls, which result in a confirmation tab the user can use to agree to the side-effects of the action (e.g. green light for scheduling a hangout).
- Various backend architectures are extended to support extended LLM querying (e.g. adding an optional method to `LLMRunner` for generating  over a multi-message conversation).

The conversation results in one of two concrete outcomes:

- `scheduleHangout`: The information from the conversation is parsed into a date, activity, and contact, and a corresponding activity is scheduled. An invitation is sent.
- `setGoal`: The information is parsed into a tracked contact, and a goal is set to hang out with them more. The current `Goal` model is explicitly centered around hangout cadence, so this is what is prompted.

## Notes

For simplicity, the initial implementation is limited to explicitly scheduling hangouts and setting goals. There is also a small state update bug where, if the user is on the `EventDashboard` when entering the chat, a scheduled hangout will not appear until the view is refreshed. This is minor.
