### PR TITLE
Move debug triggers above nav bar

### DIFF
--- a/Eta/Views/Analytics/AnalyticsDebugTrigger.swift
+++ b/Eta/Views/Analytics/AnalyticsDebugTrigger.swift
@@ -19,5 +19,6 @@ struct TripleTapBottomRightTrigger: AnalyticsDebugTrigger {
             .onTapGesture(count: 3) {
                 showDebugMenu.wrappedValue = true
             }
+            .padding(.bottom, 49)
     }
 }

--- a/Eta/Views/Reminders/ReminderDebugModifier.swift
+++ b/Eta/Views/Reminders/ReminderDebugModifier.swift
@@ -18,6 +18,7 @@ struct ReminderDebugModifier: ViewModifier {
                 .onTapGesture(count: 3) {
                     Task { await nudgeService.scheduleNudge(force: true) }
                 }
+                .padding(.bottom, 49)
             #endif
         }
     }


### PR DESCRIPTION
Debug triggers for analytics and nudge + weekly check-in notifications were interfering with two buttons in the nav bar. Translate vertically from bottom left and bottom right to above the nav bar.