### PR TITLE
Fix debug trigger interference with llm chat button

### DIFF
--- a/Eta/App/MainTabView.swift
+++ b/Eta/App/MainTabView.swift
@@ -50,7 +50,6 @@ struct MainTabView: View {
                 )
             }
         }
-        .analyticsDebug(service: analyticsService)
         .sheet(isPresented: Binding(
             get: { invitationManager.pendingFeedbackHangoutID != nil },
             set: { if !$0 { invitationManager.dismissFeedback() } }
@@ -68,7 +67,7 @@ struct MainTabView: View {
                 .padding(.trailing, 20)
                 .padding(.bottom, 72) // clears the tab bar (≈49pt) + breathing room
         }
-        .analyticsDebug(service: analyticsService)
+//        .analyticsDebug(service: analyticsService)
         .onChange(of: selectedTab) { _, newTab in
             guard newTab == .availability else { return }
             Task {

--- a/Eta/App/MainTabView.swift
+++ b/Eta/App/MainTabView.swift
@@ -67,7 +67,7 @@ struct MainTabView: View {
                 .padding(.trailing, 20)
                 .padding(.bottom, 72) // clears the tab bar (≈49pt) + breathing room
         }
-//        .analyticsDebug(service: analyticsService)
+        .analyticsDebug(service: analyticsService)
         .onChange(of: selectedTab) { _, newTab in
             guard newTab == .availability else { return }
             Task {

--- a/Eta/Views/Analytics/AnalyticsDebugModifier.swift
+++ b/Eta/Views/Analytics/AnalyticsDebugModifier.swift
@@ -19,7 +19,7 @@ struct AnalyticsDebugModifier<Trigger: AnalyticsDebugTrigger>: ViewModifier {
     @State private var showingDebugMenu = false
 
     func body(content: Content) -> some View {
-        ZStack(alignment: .bottomTrailing) {
+        ZStack(alignment: .bottomLeading) {
             content
 
             #if DEBUG

--- a/Eta/Views/Analytics/AnalyticsDebugModifier.swift
+++ b/Eta/Views/Analytics/AnalyticsDebugModifier.swift
@@ -19,7 +19,7 @@ struct AnalyticsDebugModifier<Trigger: AnalyticsDebugTrigger>: ViewModifier {
     @State private var showingDebugMenu = false
 
     func body(content: Content) -> some View {
-        ZStack(alignment: .bottomLeading) {
+        ZStack(alignment: .trailing) {
             content
 
             #if DEBUG

--- a/Eta/Views/Analytics/AnalyticsDebugTrigger.swift
+++ b/Eta/Views/Analytics/AnalyticsDebugTrigger.swift
@@ -16,7 +16,7 @@ struct TripleTapBottomRightTrigger: AnalyticsDebugTrigger {
         Color.clear
             .frame(width: 80, height: 80)
             .contentShape(Rectangle())
-            .onTapGesture(count: 3) {
+            .onTapGesture(count: 5) {
                 showDebugMenu.wrappedValue = true
             }
             .padding(.bottom, 49)


### PR DESCRIPTION
Move the analytics debug trigger to the middle right, since the overlay was interfering with accessing the LLM chat button.