### PR TITLE
Update Weekly Self Check-In (Settings, Enriched View, Priority Propagation)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,14 +126,17 @@ Eta/
 │   ├── NudgeScheduler.swift              # Builds a Suggestion from a free slot for direct scheduling from nudge
 │   ├── NudgeReminderState.swift          # @Observable — bridges nudge notification tap → NudgeReminderSheet
 │   ├── ReminderPhotoState.swift          # @Observable — bridges photo-capture notification tap → photo sheet
-│   ├── WeeklyCheckInService.swift        # Schedules weekly check-in notification (once per calendar week)
+│   ├── WeeklyCheckInService.swift        # Schedules weekly check-in notification using user-configured day/time;
+│   │                                     #   independent of enableNotifications; reschedule() after settings change
 │   ├── WeeklyCheckInState.swift          # @Observable — bridges weekly check-in tap → WeeklyCheckInView
-│   ├── PreferencesService.swift          # Reads/writes UserPreferences from UserDefaults
+│   ├── PreferencesService.swift          # Reads/writes UserPreferences from UserDefaults; also owns week-keyed
+│   │                                     #   priority API (weeklyPriorityContactID, dismiss escalation, completion)
 │   ├── AnalyticsService.swift            # Logs analytics events to SwiftData
 │   └── AnalyticsService+CustomEvents.swift
 │
 ├── ViewModels/
-│   ├── SuggestionViewModel.swift         # Drives SuggestionView; scheduleFromNudge reuses accepted→sent flow
+│   ├── SuggestionViewModel.swift         # Drives SuggestionView; scheduleFromNudge reuses accepted→sent flow;
+│   │                                     #   dismiss() increments weekly dismiss count when priority friend is dismissed
 │   ├── ConnectionsViewModel.swift        # Drives ConnectionsView; owns healthScores dictionary
 │   ├── UpcomingEventsViewModel.swift     # Drives UpcomingEventsDashboard
 │   └── OnboardingViewModel.swift         # Drives OnboardingView; persists completion flag
@@ -143,7 +146,8 @@ Eta/
     │   ├── SuggestionView.swift          # Suggestion tab root
     │   └── SuggestionCard.swift          # Shows rotating activity photo thumbnail
     ├── Connections/
-    │   ├── ConnectionsView.swift
+    │   ├── ConnectionsView.swift         # Priority card at top of list when priority set; gear + check-in button
+    │   │                                 #   grouped in leading toolbar; + (add friend) alone on trailing
     │   └── AddConnectionSheet.swift
     ├── UpcomingEvents/
     │   ├── UpcomingEventsDashboard.swift  # Events tab root; shows ReceivedInviteCards above event cards
@@ -158,7 +162,9 @@ Eta/
     │   ├── ReceivedInviteSheet.swift     # Sheet on received-invite notification tap; Accept / Decline / Answer Later
     │   └── ReminderDebugModifier.swift   # Triple-tap bottom-left debug trigger for photo sheet
     ├── WeeklyCheckIn/
-    │   └── WeeklyCheckInView.swift       # Full-screen sheet: weekly stats, overdue friends, goal picker
+    │   └── WeeklyCheckInView.swift       # Sheet: weekly stats (seen/overdue), upcoming hangouts this week,
+    │                                     #   active goals with progress rings, network concentration nudge,
+    │                                     #   priority picker with "View suggestions" / "Send check-in" actions
     ├── Onboarding/
     │   ├── OnboardingView.swift
     │   └── PhoneSetupView.swift          # Shown before main app if no identifier registered; saves to PhoneSetupService
@@ -242,21 +248,24 @@ EtaApp
  ├─ RelationshipService(providers: [CalendarDataProvider], repository:, hangoutRepository:, preferencesService:)
  ├─ DefaultContextEngine(sources: [EventHistoryContextSource, PreferencesContextSource])
  ├─ LLMActivityStrategy(runner: GitHubModelsLLMRunner())
- ├─ SuggestionService(calendar: CalendarDataProvider, relationshipService:, contextEngine:, activityStrategy:)
+ ├─ SuggestionService(availabilityProvider:, relationshipService:, contextEngine:, activityStrategy:,
+ │                    fallbackStrategy:, preferencesService:)
  ├─ iMessageInviteProvider()
  ├─ InviteService(provider: iMessageInviteProvider, hangoutRepository:, calendarDataProvider:)
  ├─ LocalNotificationService(preferencesService:)
  ├─ InvitationManager(notificationService:, modelContext:, supabaseService:, phoneSetupService:, pendingReceivedRepo:)
  │       .receivedInviteState = receivedInviteState   ← set after construction
  ├─ NudgeService(relationshipService:, photoRepository:, runner: GitHubModelsLLMRunner())
- ├─ NudgeScheduler(calendarDataProvider:)
- ├─ WeeklyCheckInService()
+ ├─ NudgeScheduler(availabilityDataProvider:)
+ ├─ WeeklyCheckInService(preferencesService:)
  ├─ AnalyticsService(modelContext:)
  ├─ NotificationDelegate(invitationManager:, reminderPhotoState:, weeklyCheckInState:, nudgeReminderState:, receivedInviteState:)
  │       ← held strongly on EtaApp; UNUserNotificationCenter.delegate is weak
- ├─ SuggestionViewModel(suggestionService:, inviteService:, invitationManager:, formatter:, photoRepository:)
+ ├─ SuggestionViewModel(suggestionService:, inviteService:, invitationManager:, formatter:, photoRepository:,
+ │                       preferencesService:)
  ├─ ConnectionsViewModel(repository:, formatter:, relationshipService:)
  ├─ UpcomingEventsViewModel(hangoutRepository:, pendingInviteRepository:, invitationManager:, formatter:)
+ ├─ SettingsViewModel(preferencesService:, weeklyCheckInService:, onClearAll:)
  └─ MainTabView(connectionsViewModel:, suggestionViewModel:, upcomingEventsViewModel:, analyticsService:,
                 photoRepository:, reminderPhotoState:, nudgeService:, nudgeScheduler:,
                 weeklyCheckInService:, weeklyCheckInState:, nudgeReminderState:, receivedInviteState:)
@@ -556,14 +565,64 @@ Sheet presented when the user taps a nudge notification:
 
 ## Weekly check-in
 
-`WeeklyCheckInService` schedules a local notification once per calendar week. Tap routes through `NotificationDelegate` → `WeeklyCheckInState` → `WeeklyCheckInView` sheet in `MainTabView`.
+`WeeklyCheckInService` schedules a recurring local notification on a user-configured weekday and time. It is independent of the global `enableNotifications` preference — it has its own toggle in Settings. Tap routes through `NotificationDelegate` → `WeeklyCheckInState` → `WeeklyCheckInView` sheet in `MainTabView`. The check-in button (`checkmark.circle`) also appears in the leading toolbar of `ConnectionsView` (alongside the gear) for in-app access anytime. A badge dot shows when the check-in has not been completed this week and at least one friend exists.
 
-### WeeklyCheckInView data
+### Settings
 
-- Always re-fetches contacts and health scores on appearance (no stale-cache guard).
-- **"Seen this week"** — contacts whose `lastHangoutDate >= weekStart` (calendar-week boundary, not rolling 7 days).
-- **"Overdue"** — contacts whose `lastHangoutDate < weekStart`, excluding any contact with a confirmed upcoming hangout.
-- **Goal** — user picks one friend to prioritise; persisted in `UserDefaults` keyed to the current `weekStart` timestamp so it resets automatically on the next calendar week.
+`UserPreferences` carries three new fields:
+- `weeklyCheckInEnabled: Bool` — default `true`
+- `weeklyCheckInDay: Int` — weekday (1 = Sunday … 7 = Saturday), default Sunday
+- `weeklyCheckInTime: Date` — only hour/minute used, default 6 pm
+
+Changing any of these calls `WeeklyCheckInService.reschedule()`, which cancels the pending notification and re-schedules with the new components. Clear All Data resets priority/dismiss state but preserves day/time.
+
+### WeeklyCheckInView sections
+
+Always re-fetches on appearance (no stale-cache guard). Sections in order:
+
+1. **Header** — week range label + "How are your friendships doing?"
+2. **Stats** — two stat cards: friends seen this week / friends overdue
+3. **Planned this week** — upcoming confirmed hangouts before week end (hidden if none)
+4. **Who needs your attention?** — overdue friends list (score-sorted); "You're all caught up!" if none
+5. **Your goals** — active goals with progress rings recycled from the `Goal` model (hidden if none)
+6. **Network nudge** — shown when >65% of confirmed hangouts in the last 30 days involve only 1–2 contacts and there are ≥5 hangouts in that window
+7. **Priority picker** — candidates sorted by health score; tap to select/deselect. When a friend is selected, two action buttons appear: **View suggestions** (saves priority, marks done, switches to Suggestions tab) and **Send check-in** (opens `CheckInSheet`; only shown if contact has a phone number).
+
+Done button saves the selected priority and marks the check-in completed. Swipe-to-dismiss does not save.
+
+### Weekly priority contact
+
+The priority contact is stored as a week-keyed UserDefaults entry (`wcp_<weekStart>_id`) so it auto-resets each new calendar week with no explicit cleanup. `PreferencesService` owns the full API:
+
+- `weeklyPriorityContactID()` / `setWeeklyPriority(_:)` — read/write; setting resets dismiss count and suppression
+- `weeklyDismissCount()` / `incrementWeeklyDismissCount()` — tracks dismissals of the priority friend from suggestions
+- `isWeeklyPrioritySuppressed()` — true if 2nd dismiss was within the last 24 hours
+- `isWeeklyPriorityWaived()` — true if dismiss count ≥ 3 (waived for rest of week)
+- `hasCompletedCheckInThisWeek()` / `markCheckInCompleted()` — drives the badge dot
+- `clearWeeklyData()` — clears priority + dismiss state + done flag; does NOT clear day/time
+
+### Priority propagation to suggestions
+
+`SuggestionService.topContact()` picks the priority contact first when:
+- A priority is set (`weeklyPriorityContactID` is non-nil)
+- Not suppressed (`isWeeklyPrioritySuppressed() == false`)
+- Not waived (`isWeeklyPriorityWaived() == false`)
+- Contact has a non-zero health score (score > 0 means no confirmed upcoming hangout)
+
+Falls back to the highest-scoring contact ≥ 7.0 threshold when no priority is active or the priority contact is ineligible.
+
+### Dismiss escalation
+
+`SuggestionViewModel.dismiss()` calls `preferencesService.incrementWeeklyDismissCount()` when the dismissed suggestion's contact matches the current priority. Escalation:
+- 1st dismiss — priority survives next refresh
+- 2nd dismiss — 24-hour suppression (priority friend not suggested, but count still increments if they appear naturally)
+- 3rd dismiss — waived for the rest of the week
+
+Count resets automatically each new week (week key rolls over) and whenever `setWeeklyPriority` is called (including reselection).
+
+### Priority card in ConnectionsView
+
+When a priority contact is set, a card appears at the top of the friends list showing the contact name and a **Clear** button. Tapping Clear calls `homeViewModel.saveWeeklyGoal(contactID: nil)`, which clears the priority immediately (reactive — no refresh needed). The card does not auto-clear when a hangout is confirmed; it persists until Clear is tapped, the user deselects + Done in check-in, or a new week starts.
 
 ---
 
@@ -579,7 +638,7 @@ Sheet presented when the user taps a nudge notification:
    c. Calls `strategy.suggest(from: healthScores)` — the strategy returns nil if no contact exceeds the recency threshold (score < 7, i.e. seen within the last week). If nil → returns nil.
    d. Attaches `proposedTime` from step (a) to the strategy's result and returns the complete `Suggestion`.
 3. Result (or nil) flows back to `SuggestionViewModel` — view renders the card or the empty inbox state.
-4. User taps **"Maybe Later"** → `SuggestionViewModel.dismiss()` sets `suggestion = nil`. Nothing is persisted; the next `refresh()` recomputes from scratch.
+4. User taps **"Maybe Later"** → `SuggestionViewModel.dismiss()` sets `suggestion = nil`. If the dismissed contact is the weekly priority friend, the weekly dismiss count is incremented (see dismiss escalation in Weekly check-in section). Nothing else is persisted; the next `refresh()` recomputes from scratch.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,14 +126,17 @@ Eta/
 │   ├── NudgeScheduler.swift              # Builds a Suggestion from a free slot for direct scheduling from nudge
 │   ├── NudgeReminderState.swift          # @Observable — bridges nudge notification tap → NudgeReminderSheet
 │   ├── ReminderPhotoState.swift          # @Observable — bridges photo-capture notification tap → photo sheet
-│   ├── WeeklyCheckInService.swift        # Schedules weekly check-in notification (once per calendar week)
+│   ├── WeeklyCheckInService.swift        # Schedules weekly check-in notification using user-configured day/time;
+│   │                                     #   independent of enableNotifications; reschedule() after settings change
 │   ├── WeeklyCheckInState.swift          # @Observable — bridges weekly check-in tap → WeeklyCheckInView
-│   ├── PreferencesService.swift          # Reads/writes UserPreferences from UserDefaults
+│   ├── PreferencesService.swift          # Reads/writes UserPreferences from UserDefaults; also owns week-keyed
+│   │                                     #   priority API (weeklyPriorityContactID, dismiss escalation, completion)
 │   ├── AnalyticsService.swift            # Logs analytics events to SwiftData
 │   └── AnalyticsService+CustomEvents.swift
 │
 ├── ViewModels/
-│   ├── SuggestionViewModel.swift         # Drives SuggestionView; scheduleFromNudge reuses accepted→sent flow
+│   ├── SuggestionViewModel.swift         # Drives SuggestionView; scheduleFromNudge reuses accepted→sent flow;
+│   │                                     #   dismiss() increments weekly dismiss count when priority friend is dismissed
 │   ├── ConnectionsViewModel.swift        # Drives ConnectionsView; owns healthScores dictionary
 │   ├── UpcomingEventsViewModel.swift     # Drives UpcomingEventsDashboard
 │   └── OnboardingViewModel.swift         # Drives OnboardingView; persists completion flag
@@ -143,7 +146,8 @@ Eta/
     │   ├── SuggestionView.swift          # Suggestion tab root
     │   └── SuggestionCard.swift          # Shows rotating activity photo thumbnail
     ├── Connections/
-    │   ├── ConnectionsView.swift
+    │   ├── ConnectionsView.swift         # Priority card at top of list when priority set; gear + check-in button
+    │   │                                 #   grouped in leading toolbar; + (add friend) alone on trailing
     │   └── AddConnectionSheet.swift
     ├── UpcomingEvents/
     │   ├── UpcomingEventsDashboard.swift  # Events tab root; shows ReceivedInviteCards above event cards
@@ -158,7 +162,9 @@ Eta/
     │   ├── ReceivedInviteSheet.swift     # Sheet on received-invite notification tap; Accept / Decline / Answer Later
     │   └── ReminderDebugModifier.swift   # Triple-tap bottom-left debug trigger for photo sheet
     ├── WeeklyCheckIn/
-    │   └── WeeklyCheckInView.swift       # Full-screen sheet: weekly stats, overdue friends, goal picker
+    │   └── WeeklyCheckInView.swift       # Sheet: weekly stats (seen/overdue), upcoming hangouts this week,
+    │                                     #   active goals with progress rings, network concentration nudge,
+    │                                     #   priority picker with "View suggestions" / "Send check-in" actions
     ├── Onboarding/
     │   ├── OnboardingView.swift
     │   └── PhoneSetupView.swift          # Shown before main app if no identifier registered; saves to PhoneSetupService
@@ -242,21 +248,24 @@ EtaApp
  ├─ RelationshipService(providers: [CalendarDataProvider], repository:, hangoutRepository:, preferencesService:)
  ├─ DefaultContextEngine(sources: [EventHistoryContextSource, PreferencesContextSource])
  ├─ LLMActivityStrategy(runner: GitHubModelsLLMRunner())
- ├─ SuggestionService(calendar: CalendarDataProvider, relationshipService:, contextEngine:, activityStrategy:)
+ ├─ SuggestionService(availabilityProvider:, relationshipService:, contextEngine:, activityStrategy:,
+ │                    fallbackStrategy:, preferencesService:)
  ├─ iMessageInviteProvider()
  ├─ InviteService(provider: iMessageInviteProvider, hangoutRepository:, calendarDataProvider:)
  ├─ LocalNotificationService(preferencesService:)
  ├─ InvitationManager(notificationService:, modelContext:, supabaseService:, phoneSetupService:, pendingReceivedRepo:)
  │       .receivedInviteState = receivedInviteState   ← set after construction
  ├─ NudgeService(relationshipService:, photoRepository:, runner: GitHubModelsLLMRunner())
- ├─ NudgeScheduler(calendarDataProvider:)
- ├─ WeeklyCheckInService()
+ ├─ NudgeScheduler(availabilityDataProvider:)
+ ├─ WeeklyCheckInService(preferencesService:)
  ├─ AnalyticsService(modelContext:)
  ├─ NotificationDelegate(invitationManager:, reminderPhotoState:, weeklyCheckInState:, nudgeReminderState:, receivedInviteState:)
  │       ← held strongly on EtaApp; UNUserNotificationCenter.delegate is weak
- ├─ SuggestionViewModel(suggestionService:, inviteService:, invitationManager:, formatter:, photoRepository:)
+ ├─ SuggestionViewModel(suggestionService:, inviteService:, invitationManager:, formatter:, photoRepository:,
+ │                       preferencesService:)
  ├─ ConnectionsViewModel(repository:, formatter:, relationshipService:)
  ├─ UpcomingEventsViewModel(hangoutRepository:, pendingInviteRepository:, invitationManager:, formatter:)
+ ├─ SettingsViewModel(preferencesService:, weeklyCheckInService:, onClearAll:)
  └─ MainTabView(connectionsViewModel:, suggestionViewModel:, upcomingEventsViewModel:, analyticsService:,
                 photoRepository:, reminderPhotoState:, nudgeService:, nudgeScheduler:,
                 weeklyCheckInService:, weeklyCheckInState:, nudgeReminderState:, receivedInviteState:)
@@ -556,14 +565,64 @@ Sheet presented when the user taps a nudge notification:
 
 ## Weekly check-in
 
-`WeeklyCheckInService` schedules a local notification once per calendar week. Tap routes through `NotificationDelegate` → `WeeklyCheckInState` → `WeeklyCheckInView` sheet in `MainTabView`.
+`WeeklyCheckInService` schedules a recurring local notification on a user-configured weekday and time. It is independent of the global `enableNotifications` preference — it has its own toggle in Settings. Tap routes through `NotificationDelegate` → `WeeklyCheckInState` → `WeeklyCheckInView` sheet in `MainTabView`. The check-in button (`checkmark.circle`) also appears in the leading toolbar of `ConnectionsView` (alongside the gear) for in-app access anytime. A badge dot shows when the check-in has not been completed this week and at least one friend exists.
 
-### WeeklyCheckInView data
+### Settings
 
-- Always re-fetches contacts and health scores on appearance (no stale-cache guard).
-- **"Seen this week"** — contacts whose `lastHangoutDate >= weekStart` (calendar-week boundary, not rolling 7 days).
-- **"Overdue"** — contacts whose `lastHangoutDate < weekStart`, excluding any contact with a confirmed upcoming hangout.
-- **Goal** — user picks one friend to prioritise; persisted in `UserDefaults` keyed to the current `weekStart` timestamp so it resets automatically on the next calendar week.
+`UserPreferences` carries three new fields:
+- `weeklyCheckInEnabled: Bool` — default `true`
+- `weeklyCheckInDay: Int` — weekday (1 = Sunday … 7 = Saturday), default Sunday
+- `weeklyCheckInTime: Date` — only hour/minute used, default 6 pm
+
+Changing any of these calls `WeeklyCheckInService.reschedule()`, which cancels the pending notification and re-schedules with the new components. Clear All Data resets priority/dismiss state but preserves day/time.
+
+### WeeklyCheckInView sections
+
+Always re-fetches on appearance (no stale-cache guard). Sections in order:
+
+1. **Header** — week range label + "How are your friendships doing?"
+2. **Stats** — two stat cards: friends seen this week / friends overdue
+3. **Planned this week** — upcoming confirmed hangouts before week end (hidden if none)
+4. **Who needs your attention?** — overdue friends list (score-sorted); "You're all caught up!" if none
+5. **Your goals** — active goals with progress rings recycled from the `Goal` model (hidden if none)
+6. **Network nudge** — shown when >65% of confirmed hangouts in the last 30 days involve only 1–2 contacts and there are ≥5 hangouts in that window
+7. **Priority picker** — candidates sorted by health score; tap to select/deselect. When a friend is selected, two action buttons appear: **View suggestions** (saves priority, marks done, switches to Suggestions tab) and **Send check-in** (opens `CheckInSheet`; only shown if contact has a phone number).
+
+Done button saves the selected priority and marks the check-in completed. Swipe-to-dismiss does not save.
+
+### Weekly priority contact
+
+The priority contact is stored as a week-keyed UserDefaults entry (`wcp_<weekStart>_id`) so it auto-resets each new calendar week with no explicit cleanup. `PreferencesService` owns the full API:
+
+- `weeklyPriorityContactID()` / `setWeeklyPriority(_:)` — read/write; setting resets dismiss count and suppression
+- `weeklyDismissCount()` / `incrementWeeklyDismissCount()` — tracks dismissals of the priority friend from suggestions
+- `isWeeklyPrioritySuppressed()` — true if 2nd dismiss was within the last 24 hours
+- `isWeeklyPriorityWaived()` — true if dismiss count ≥ 3 (waived for rest of week)
+- `hasCompletedCheckInThisWeek()` / `markCheckInCompleted()` — drives the badge dot
+- `clearWeeklyData()` — clears priority + dismiss state + done flag; does NOT clear day/time
+
+### Priority propagation to suggestions
+
+`SuggestionService.topContact()` picks the priority contact first when:
+- A priority is set (`weeklyPriorityContactID` is non-nil)
+- Not suppressed (`isWeeklyPrioritySuppressed() == false`)
+- Not waived (`isWeeklyPriorityWaived() == false`)
+- Contact has a non-zero health score (score > 0 means no confirmed upcoming hangout)
+
+Falls back to the highest-scoring contact ≥ 7.0 threshold when no priority is active or the priority contact is ineligible.
+
+### Dismiss escalation
+
+`SuggestionViewModel.dismiss()` calls `preferencesService.incrementWeeklyDismissCount()` when the dismissed suggestion's contact matches the current priority. Escalation:
+- 1st dismiss — priority survives next refresh
+- 2nd dismiss — 24-hour suppression (priority friend not suggested, but count still increments if they appear naturally)
+- 3rd dismiss — waived for the rest of the week
+
+Count resets automatically each new week (week key rolls over) and whenever `setWeeklyPriority` is called (including reselection).
+
+### Priority card in ConnectionsView
+
+When a priority contact is set, a card appears at the top of the friends list showing the contact name and a **Clear** button. Tapping Clear calls `homeViewModel.saveWeeklyGoal(contactID: nil)`, which clears the priority immediately (reactive — no refresh needed). The card does not auto-clear when a hangout is confirmed; it persists until Clear is tapped, the user deselects + Done in check-in, or a new week starts.
 
 ---
 
@@ -579,7 +638,7 @@ Sheet presented when the user taps a nudge notification:
    c. Calls `strategy.suggest(from: healthScores)` — the strategy returns nil if no contact exceeds the recency threshold (score < 7, i.e. seen within the last week). If nil → returns nil.
    d. Attaches `proposedTime` from step (a) to the strategy's result and returns the complete `Suggestion`.
 3. Result (or nil) flows back to `SuggestionViewModel` — view renders the card or the empty inbox state.
-4. User taps **"Maybe Later"** → `SuggestionViewModel.dismiss()` sets `suggestion = nil`. Nothing is persisted; the next `refresh()` recomputes from scratch.
+4. User taps **"Maybe Later"** → `SuggestionViewModel.dismiss()` sets `suggestion = nil`. If the dismissed contact is the weekly priority friend, the weekly dismiss count is incremented (see dismiss escalation in Weekly check-in section). Nothing else is persisted; the next `refresh()` recomputes from scratch.
 
 ---
 

--- a/Eta/App/MainTabView.swift
+++ b/Eta/App/MainTabView.swift
@@ -37,7 +37,8 @@ struct MainTabView: View {
                     viewModel: connectionsViewModel,
                     homeViewModel: homeViewModel,
                     settingsViewModel: settingsViewModel,
-                    analyticsService: analyticsService
+                    analyticsService: analyticsService,
+                    weeklyCheckInState: weeklyCheckInState
                 )
             }
             Tab("Events", systemImage: "cup.and.saucer", value: .events) {
@@ -109,7 +110,12 @@ struct MainTabView: View {
         )) {
             WeeklyCheckInView(
                 connectionsViewModel: connectionsViewModel,
-                onDismiss: { weeklyCheckInState.clear() }
+                homeViewModel: homeViewModel,
+                onDismiss: { weeklyCheckInState.clear() },
+                onViewSuggestions: {
+                    weeklyCheckInState.clear()
+                    selectedTab = .suggestions
+                }
             )
         }
         .sheet(isPresented: Binding(

--- a/Eta/EtaApp.swift
+++ b/Eta/EtaApp.swift
@@ -95,7 +95,7 @@ struct EtaApp: App {
             runner: GitHubModelsLLMRunner()
         )
         self.nudgeService = nudgeService
-        self.weeklyCheckInService = WeeklyCheckInService()
+        self.weeklyCheckInService = WeeklyCheckInService(preferencesService: preferencesService)
         let weeklyCheckInState = WeeklyCheckInState()
         self.weeklyCheckInState = weeklyCheckInState
         let nudgeReminderState = NudgeReminderState()
@@ -123,7 +123,8 @@ struct EtaApp: App {
             relationshipService: relationshipService,
             contextEngine: contextEngine,
             activityStrategy: activityStrategy,
-            fallbackStrategy: fallbackStrategy
+            fallbackStrategy: fallbackStrategy,
+            preferencesService: preferencesService
         )
         let inviteProvider = iMessageInviteProvider()
         let inviteService = InviteService(
@@ -181,7 +182,8 @@ struct EtaApp: App {
             inviteService: inviteService,
             invitationManager: invitationManager,
             formatter: formatter,
-            photoRepository: photoRepository
+            photoRepository: photoRepository,
+            preferencesService: preferencesService
         )
         self.upcomingEventsViewModel = UpcomingEventsViewModel(
             hangoutRepository: hangoutRepository,
@@ -203,6 +205,7 @@ struct EtaApp: App {
 
         self.settingsViewModel = SettingsViewModel(
             preferencesService: preferencesService,
+            weeklyCheckInService: weeklyCheckInService,
             onClearAll: {
                 try? ctx.delete(model: TrackedContact.self)
                 try? ctx.delete(model: ScheduledHangout.self)

--- a/Eta/Models/UserPreferences.swift
+++ b/Eta/Models/UserPreferences.swift
@@ -8,6 +8,12 @@ struct UserPreferences: Codable {
     var notificationTime: Date
     var checkInTemplate: String?
     var hasSetCheckInTemplate: Bool
+    /// Whether the weekly check-in notification is enabled. Independent of enableNotifications.
+    var weeklyCheckInEnabled: Bool
+    /// Weekday for the weekly check-in notification: 1 = Sunday … 7 = Saturday.
+    var weeklyCheckInDay: Int
+    /// Time of day for the weekly check-in notification. Only hour/minute components are used.
+    var weeklyCheckInTime: Date
 
     init(
         preferredActivities: [String] = Activity.allCases.map { $0.rawValue },
@@ -21,7 +27,15 @@ struct UserPreferences: Codable {
             return Calendar.current.date(from: components) ?? Date()
         }(),
         checkInTemplate: String? = nil,
-        hasSetCheckInTemplate: Bool = false
+        hasSetCheckInTemplate: Bool = false,
+        weeklyCheckInEnabled: Bool = true,
+        weeklyCheckInDay: Int = 1,
+        weeklyCheckInTime: Date = {
+            var components = DateComponents()
+            components.hour = 18
+            components.minute = 0
+            return Calendar.current.date(from: components) ?? Date()
+        }()
     ) {
         self.preferredActivities = preferredActivities
         self.relationshipHealthThreshold = relationshipHealthThreshold
@@ -30,6 +44,9 @@ struct UserPreferences: Codable {
         self.notificationTime = notificationTime
         self.checkInTemplate = checkInTemplate
         self.hasSetCheckInTemplate = hasSetCheckInTemplate
+        self.weeklyCheckInEnabled = weeklyCheckInEnabled
+        self.weeklyCheckInDay = weeklyCheckInDay
+        self.weeklyCheckInTime = weeklyCheckInTime
     }
 
     func encode(to encoder: Encoder) throws {
@@ -41,6 +58,9 @@ struct UserPreferences: Codable {
         try container.encode(notificationTime.timeIntervalSince1970, forKey: .notificationTimeInterval)
         try container.encodeIfPresent(checkInTemplate, forKey: .checkInTemplate)
         try container.encode(hasSetCheckInTemplate, forKey: .hasSetCheckInTemplate)
+        try container.encode(weeklyCheckInEnabled, forKey: .weeklyCheckInEnabled)
+        try container.encode(weeklyCheckInDay, forKey: .weeklyCheckInDay)
+        try container.encode(weeklyCheckInTime.timeIntervalSince1970, forKey: .weeklyCheckInTimeInterval)
     }
 
     init(from decoder: Decoder) throws {
@@ -53,6 +73,15 @@ struct UserPreferences: Codable {
         notificationTime = Date(timeIntervalSince1970: timeInterval)
         checkInTemplate = try container.decodeIfPresent(String.self, forKey: .checkInTemplate)
         hasSetCheckInTemplate = try container.decodeIfPresent(Bool.self, forKey: .hasSetCheckInTemplate) ?? false
+        weeklyCheckInEnabled = try container.decodeIfPresent(Bool.self, forKey: .weeklyCheckInEnabled) ?? true
+        weeklyCheckInDay = try container.decodeIfPresent(Int.self, forKey: .weeklyCheckInDay) ?? 1
+        let checkInTimeInterval = try container.decodeIfPresent(TimeInterval.self, forKey: .weeklyCheckInTimeInterval)
+        if let t = checkInTimeInterval {
+            weeklyCheckInTime = Date(timeIntervalSince1970: t)
+        } else {
+            var c = DateComponents(); c.hour = 18; c.minute = 0
+            weeklyCheckInTime = Calendar.current.date(from: c) ?? Date()
+        }
     }
 
     enum CodingKeys: String, CodingKey {
@@ -63,5 +92,8 @@ struct UserPreferences: Codable {
         case notificationTimeInterval
         case checkInTemplate
         case hasSetCheckInTemplate
+        case weeklyCheckInEnabled
+        case weeklyCheckInDay
+        case weeklyCheckInTimeInterval
     }
 }

--- a/Eta/Services/PreferencesService.swift
+++ b/Eta/Services/PreferencesService.swift
@@ -29,6 +29,70 @@ final class PreferencesService {
         savePreferences()
     }
 
+    // MARK: - Weekly priority (week-keyed UserDefaults, resets automatically each new week)
+
+    private var weekKey: String {
+        let ts = Calendar.current.dateInterval(of: .weekOfYear, for: .now)?.start.timeIntervalSince1970 ?? 0
+        return "wcp_\(Int(ts))"
+    }
+
+    func weeklyPriorityContactID() -> UUID? {
+        guard let str = UserDefaults.standard.string(forKey: weekKey + "_id") else { return nil }
+        return UUID(uuidString: str)
+    }
+
+    func setWeeklyPriority(_ contactID: UUID?) {
+        if let id = contactID {
+            UserDefaults.standard.set(id.uuidString, forKey: weekKey + "_id")
+        } else {
+            UserDefaults.standard.removeObject(forKey: weekKey + "_id")
+        }
+        // Reset dismiss state whenever the priority contact changes.
+        UserDefaults.standard.removeObject(forKey: weekKey + "_dismissCount")
+        UserDefaults.standard.removeObject(forKey: weekKey + "_suppressedUntil")
+    }
+
+    func weeklyDismissCount() -> Int {
+        UserDefaults.standard.integer(forKey: weekKey + "_dismissCount")
+    }
+
+    /// Increments the dismiss count and applies suppression/waiver thresholds.
+    /// 2nd dismiss → 24-hour suppression. 3rd dismiss → priority waived for rest of week.
+    func incrementWeeklyDismissCount() {
+        let newCount = weeklyDismissCount() + 1
+        UserDefaults.standard.set(newCount, forKey: weekKey + "_dismissCount")
+        if newCount == 2 {
+            let until = Date().addingTimeInterval(24 * 60 * 60).timeIntervalSince1970
+            UserDefaults.standard.set(until, forKey: weekKey + "_suppressedUntil")
+        }
+    }
+
+    func isWeeklyPrioritySuppressed() -> Bool {
+        let until = UserDefaults.standard.double(forKey: weekKey + "_suppressedUntil")
+        guard until > 0 else { return false }
+        return Date() < Date(timeIntervalSince1970: until)
+    }
+
+    func isWeeklyPriorityWaived() -> Bool {
+        weeklyDismissCount() >= 3
+    }
+
+    func hasCompletedCheckInThisWeek() -> Bool {
+        UserDefaults.standard.bool(forKey: weekKey + "_done")
+    }
+
+    func markCheckInCompleted() {
+        UserDefaults.standard.set(true, forKey: weekKey + "_done")
+    }
+
+    /// Clears weekly priority and dismiss state. Does NOT reset day/time preferences.
+    func clearWeeklyData() {
+        UserDefaults.standard.removeObject(forKey: weekKey + "_id")
+        UserDefaults.standard.removeObject(forKey: weekKey + "_dismissCount")
+        UserDefaults.standard.removeObject(forKey: weekKey + "_suppressedUntil")
+        UserDefaults.standard.removeObject(forKey: weekKey + "_done")
+    }
+
     private func savePreferences() {
         if let encoded = try? JSONEncoder().encode(preferences) {
             UserDefaults.standard.set(encoded, forKey: "userPreferences")

--- a/Eta/Services/SuggestionService.swift
+++ b/Eta/Services/SuggestionService.swift
@@ -19,6 +19,7 @@ final class SuggestionService {
     private let contextEngine: any ContextEngine
     private let activityStrategy: any ActivityStrategy
     private let fallbackStrategy: RulesActivityStrategy
+    private let preferencesService: PreferencesService
 
     /// Contacts with a health score below this threshold are considered "recently seen"
     /// and do not qualify for a suggestion. 7.0 corresponds to roughly one week.
@@ -29,13 +30,15 @@ final class SuggestionService {
         relationshipService: RelationshipService,
         contextEngine: any ContextEngine,
         activityStrategy: any ActivityStrategy,
-        fallbackStrategy: RulesActivityStrategy
+        fallbackStrategy: RulesActivityStrategy,
+        preferencesService: PreferencesService
     ) {
         self.availabilityProvider = availabilityProvider
         self.relationshipService = relationshipService
         self.contextEngine = contextEngine
         self.activityStrategy = activityStrategy
         self.fallbackStrategy = fallbackStrategy
+        self.preferencesService = preferencesService
     }
 
     /// Returns a Suggestion when both a free slot and an overdue contact exist,
@@ -92,10 +95,23 @@ final class SuggestionService {
 
     // MARK: - Private
 
-    /// Returns the most overdue active contact above the score threshold, or nil if none qualifies.
+    /// Returns the contact to suggest.
+    /// If a weekly priority is active (not suppressed, not waived), picks that contact
+    /// as long as they have a non-zero score (no confirmed upcoming hangout).
+    /// Otherwise falls back to the highest-scoring contact above the recency threshold.
     private func topContact(from healthScores: [RelationshipHealth]) -> RelationshipHealth? {
-        healthScores
-            .filter { $0.contact.isActive && $0.score >= minimumScoreThreshold }
+        let eligible = healthScores.filter { $0.contact.isActive }
+
+        if let priorityID = preferencesService.weeklyPriorityContactID(),
+           !preferencesService.isWeeklyPrioritySuppressed(),
+           !preferencesService.isWeeklyPriorityWaived(),
+           let priorityHealth = eligible.first(where: { $0.contact.id == priorityID }),
+           priorityHealth.score > 0 {
+            return priorityHealth
+        }
+
+        return eligible
+            .filter { $0.score >= minimumScoreThreshold }
             .max(by: { $0.score < $1.score })
     }
 }

--- a/Eta/Services/WeeklyCheckInService.swift
+++ b/Eta/Services/WeeklyCheckInService.swift
@@ -1,22 +1,37 @@
 import Foundation
 import UserNotifications
 
-/// Schedules a repeating weekly notification encouraging the user to check in
-/// with their friends. Fires every Sunday at 6pm.
-///
-/// Scheduled once — repeats automatically via UNCalendarNotificationTrigger.
-/// Re-calling scheduleIfNeeded() is idempotent: skips if already pending.
+/// Schedules the weekly check-in notification using the user's configured day and time.
+/// Independent of the global `enableNotifications` preference — has its own toggle.
 final class WeeklyCheckInService {
     private static let notificationID = "me.Eta.weeklyCheckIn"
+    private let preferencesService: PreferencesService
 
-    /// Fires the weekly check-in notification in 3 seconds for debug/demo purposes.
+    init(preferencesService: PreferencesService) {
+        self.preferencesService = preferencesService
+    }
+
+    /// Schedules the notification if not already pending and check-ins are enabled.
+    func scheduleIfNeeded() async {
+        guard preferencesService.preferences.weeklyCheckInEnabled else {
+            await cancel()
+            return
+        }
+        let pending = await UNUserNotificationCenter.current().pendingNotificationRequests()
+        guard !pending.contains(where: { $0.identifier == Self.notificationID }) else { return }
+        await schedule()
+    }
+
+    /// Cancels any pending notification and reschedules with current preferences.
+    /// Call this after the user changes the day or time in Settings.
+    func reschedule() async {
+        await cancel()
+        await scheduleIfNeeded()
+    }
+
+    /// Fires in 1 second for debug/demo purposes.
     func scheduleDebug() async {
-        let content = UNMutableNotificationContent()
-        content.title = "How are your friendships doing?"
-        content.body = "Take a moment to check in with someone this week."
-        content.sound = .default
-        content.userInfo = ["notificationType": "weeklyCheckIn"]
-
+        let content = makeContent()
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
         let request = UNNotificationRequest(
             identifier: "me.Eta.weeklyCheckIn.debug.\(UUID().uuidString)",
@@ -26,27 +41,36 @@ final class WeeklyCheckInService {
         try? await UNUserNotificationCenter.current().add(request)
     }
 
-    func scheduleIfNeeded() async {
-        let pending = await UNUserNotificationCenter.current().pendingNotificationRequests()
-        guard !pending.contains(where: { $0.identifier == Self.notificationID }) else { return }
+    // MARK: - Private
 
+    private func cancel() async {
+        UNUserNotificationCenter.current()
+            .removePendingNotificationRequests(withIdentifiers: [Self.notificationID])
+    }
+
+    private func schedule() async {
+        let prefs = preferencesService.preferences
+        let cal = Calendar.current
+        var components = DateComponents()
+        components.weekday = prefs.weeklyCheckInDay
+        components.hour = cal.component(.hour, from: prefs.weeklyCheckInTime)
+        components.minute = cal.component(.minute, from: prefs.weeklyCheckInTime)
+
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+        let request = UNNotificationRequest(
+            identifier: Self.notificationID,
+            content: makeContent(),
+            trigger: trigger
+        )
+        try? await UNUserNotificationCenter.current().add(request)
+    }
+
+    private func makeContent() -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
         content.title = "How are your friendships doing?"
         content.body = "Take a moment to check in with someone this week."
         content.sound = .default
         content.userInfo = ["notificationType": "weeklyCheckIn"]
-
-        var components = DateComponents()
-        components.weekday = 1  // Sunday
-        components.hour = 18    // 6pm
-        components.minute = 0
-
-        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
-        let request = UNNotificationRequest(
-            identifier: Self.notificationID,
-            content: content,
-            trigger: trigger
-        )
-        try? await UNUserNotificationCenter.current().add(request)
+        return content
     }
 }

--- a/Eta/ViewModels/HomeViewModel.swift
+++ b/Eta/ViewModels/HomeViewModel.swift
@@ -28,6 +28,7 @@ final class HomeViewModel {
     private(set) var profileVersion: Int = 0
     private(set) var weeklyPriorityContactID: UUID? = nil
     private(set) var hasCompletedCheckInThisWeek: Bool = false
+    private(set) var hasInitiallyLoaded: Bool = false
 
     private var allHangouts: [ScheduledHangout] = []
 
@@ -130,6 +131,7 @@ final class HomeViewModel {
         currentInsight = await insightTask
         // Second pass: refresh with calendar-enhanced health data.
         friendSpotlights = computeSpotlights(healthScores: healthScores)
+        hasInitiallyLoaded = true
     }
 
     // MARK: - Insight actions

--- a/Eta/ViewModels/HomeViewModel.swift
+++ b/Eta/ViewModels/HomeViewModel.swift
@@ -26,6 +26,8 @@ final class HomeViewModel {
     private(set) var contacts: [TrackedContact] = []
     private(set) var isLoading: Bool = false
     private(set) var profileVersion: Int = 0
+    private(set) var weeklyPriorityContactID: UUID? = nil
+    private(set) var hasCompletedCheckInThisWeek: Bool = false
 
     private var allHangouts: [ScheduledHangout] = []
 
@@ -41,6 +43,36 @@ final class HomeViewModel {
 
     var checkInTemplate: String? { preferencesService.preferences.checkInTemplate }
     var hasSetCheckInTemplate: Bool { preferencesService.preferences.hasSetCheckInTemplate }
+
+    var weeklyPriorityContact: TrackedContact? {
+        guard let id = weeklyPriorityContactID else { return nil }
+        return contacts.first { $0.id == id }
+    }
+
+    /// Hangouts scheduled to start from now through end of the current calendar week.
+    var upcomingHangoutsThisWeek: [ScheduledHangout] {
+        guard let weekEnd = Calendar.current.dateInterval(of: .weekOfYear, for: .now)?.end else { return [] }
+        return allHangouts
+            .filter { $0.startDate > .now && $0.startDate < weekEnd && $0.status != .canceled }
+            .sorted { $0.startDate < $1.startDate }
+    }
+
+    /// Non-nil when >65% of confirmed hangouts in the last 30 days involve only 1–2 contacts.
+    var networkConcentrationWarning: String? {
+        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: .now) ?? .now
+        let recent = allHangouts.filter {
+            $0.startDate >= cutoff && $0.startDate <= .now && $0.inviteeResponse == .confirmed
+        }
+        guard recent.count >= 5 else { return nil }
+        var countByContact: [UUID: Int] = [:]
+        for hangout in recent {
+            guard let id = hangout.contact?.id else { continue }
+            countByContact[id, default: 0] += 1
+        }
+        let top2Sum = countByContact.values.sorted(by: >).prefix(2).reduce(0, +)
+        guard Double(top2Sum) / Double(recent.count) > 0.65 else { return nil }
+        return "Most of your recent hangouts have been with the same 1–2 people. Anyone you've been missing?"
+    }
 
     init(
         goalRepository: GoalRepository,
@@ -75,6 +107,8 @@ final class HomeViewModel {
         contacts = (try? contactRepository.fetchAll()) ?? []
         allHangouts = (try? hangoutRepository.fetchAll()) ?? []
         activeGoals = (try? goalRepository.fetchActive()) ?? []
+        weeklyPriorityContactID = preferencesService.weeklyPriorityContactID()
+        hasCompletedCheckInThisWeek = preferencesService.hasCompletedCheckInThisWeek()
 
         for contact in contacts {
             contactProfileService.inferPatternIfNeeded(for: contact, from: allHangouts)
@@ -206,6 +240,22 @@ final class HomeViewModel {
 
     func markCheckInTemplateSet() {
         preferencesService.markCheckInTemplateSet()
+    }
+
+    func saveWeeklyGoal(contactID: UUID?) {
+        preferencesService.setWeeklyPriority(contactID)
+        weeklyPriorityContactID = contactID
+    }
+
+    func markCheckInCompleted() {
+        preferencesService.markCheckInCompleted()
+        hasCompletedCheckInThisWeek = true
+    }
+
+    func friendNames(for goal: Goal) -> [String] {
+        goal.friendIDs.compactMap { id in
+            contacts.first { $0.id == id }.map { formatter.displayName(for: $0) }
+        }
     }
 
     func updateCity(_ city: String?, for contact: TrackedContact) {

--- a/Eta/ViewModels/HomeViewModel.swift
+++ b/Eta/ViewModels/HomeViewModel.swift
@@ -28,7 +28,6 @@ final class HomeViewModel {
     private(set) var profileVersion: Int = 0
     private(set) var weeklyPriorityContactID: UUID? = nil
     private(set) var hasCompletedCheckInThisWeek: Bool = false
-    private(set) var hasInitiallyLoaded: Bool = false
 
     private var allHangouts: [ScheduledHangout] = []
 
@@ -131,7 +130,6 @@ final class HomeViewModel {
         currentInsight = await insightTask
         // Second pass: refresh with calendar-enhanced health data.
         friendSpotlights = computeSpotlights(healthScores: healthScores)
-        hasInitiallyLoaded = true
     }
 
     // MARK: - Insight actions

--- a/Eta/ViewModels/SettingsViewModel.swift
+++ b/Eta/ViewModels/SettingsViewModel.swift
@@ -3,6 +3,7 @@ import Foundation
 @Observable
 final class SettingsViewModel {
     private let preferencesService: PreferencesService
+    private let weeklyCheckInService: WeeklyCheckInService
     private let onClearAll: () -> Void
 
     var preferences: UserPreferences {
@@ -10,12 +11,22 @@ final class SettingsViewModel {
         set { preferencesService.updatePreferences(newValue) }
     }
 
-    init(preferencesService: PreferencesService, onClearAll: @escaping () -> Void) {
+    init(
+        preferencesService: PreferencesService,
+        weeklyCheckInService: WeeklyCheckInService,
+        onClearAll: @escaping () -> Void
+    ) {
         self.preferencesService = preferencesService
+        self.weeklyCheckInService = weeklyCheckInService
         self.onClearAll = onClearAll
     }
 
+    func rescheduleWeeklyCheckIn() async {
+        await weeklyCheckInService.reschedule()
+    }
+
     func clearAllData() {
+        preferencesService.clearWeeklyData()
         onClearAll()
     }
 }

--- a/Eta/ViewModels/SuggestionViewModel.swift
+++ b/Eta/ViewModels/SuggestionViewModel.swift
@@ -23,19 +23,22 @@ final class SuggestionViewModel {
     private let invitationManager: InvitationManager
     private let formatter: ContactFormatter
     private let photoRepository: ActivityPhotoRepository
+    private let preferencesService: PreferencesService
 
     init(
         suggestionService: SuggestionService,
         inviteService: InviteService,
         invitationManager: InvitationManager,
         formatter: ContactFormatter,
-        photoRepository: ActivityPhotoRepository
+        photoRepository: ActivityPhotoRepository,
+        preferencesService: PreferencesService
     ) {
         self.suggestionService = suggestionService
         self.inviteService = inviteService
         self.invitationManager = invitationManager
         self.formatter = formatter
         self.photoRepository = photoRepository
+        self.preferencesService = preferencesService
     }
 
     // MARK: - Display
@@ -120,9 +123,13 @@ final class SuggestionViewModel {
         #endif
     }
 
-    /// Clears the current suggestion. The inbox will show its empty state until
-    /// the next refresh() call recomputes from scratch.
+    /// Clears the current suggestion. If the dismissed contact is the weekly priority
+    /// friend, increments the dismiss count (may trigger suppression or waiver).
     func dismiss() {
+        if let contactID = suggestion?.contact.id,
+           contactID == preferencesService.weeklyPriorityContactID() {
+            preferencesService.incrementWeeklyDismissCount()
+        }
         suggestion = nil
     }
 

--- a/Eta/Views/Connections/ConnectionsView.swift
+++ b/Eta/Views/Connections/ConnectionsView.swift
@@ -22,31 +22,7 @@ struct ConnectionsView: View {
                     )
                 } else {
                     List {
-                        if let contact = homeViewModel.weeklyPriorityContact {
-                            Section {
-                                HStack(spacing: 14) {
-                                    Image(systemName: "target")
-                                        .font(.title3)
-                                        .foregroundStyle(Color.accentColor)
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text("This week's priority")
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                        Text(homeViewModel.displayName(for: contact))
-                                            .font(.subheadline.weight(.semibold))
-                                    }
-                                    Spacer()
-                                    Button("Clear") {
-                                        homeViewModel.saveWeeklyGoal(contactID: nil)
-                                    }
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                }
-                                .padding(.vertical, 2)
-                            }
-                        }
-
-                        if !homeViewModel.friendSpotlights.isEmpty {
+                        if homeViewModel.hasInitiallyLoaded {
                             Section {
                                 ForEach(homeViewModel.friendSpotlights) { item in
                                     NavigationLink {
@@ -62,6 +38,37 @@ struct ConnectionsView: View {
                                             displayName: homeViewModel.displayName(for: item.contact)
                                         )
                                     }
+                                    .listRowBackground(Color.clear)
+                                    .listRowSeparator(.hidden)
+                                    .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+                                }
+                                if settingsViewModel.preferences.weeklyCheckInEnabled {
+                                    Button {
+                                        weeklyCheckInState.trigger()
+                                    } label: {
+                                        HStack(spacing: 14) {
+                                            Image(systemName: "checkmark.circle")
+                                                .font(.title3)
+                                                .foregroundStyle(homeViewModel.hasCompletedCheckInThisWeek ? Color.accentColor : .orange)
+                                            VStack(alignment: .leading, spacing: 3) {
+                                                Text(weeklyCheckInCaptionText)
+                                                    .font(.caption)
+                                                    .foregroundStyle(.secondary)
+                                                Text(weeklyCheckInStatusText)
+                                                    .font(.subheadline.weight(.semibold))
+                                                    .lineLimit(1)
+                                            }
+                                            Spacer(minLength: 0)
+                                            Image(systemName: "chevron.right")
+                                                .font(.caption2)
+                                                .foregroundStyle(.tertiary)
+                                        }
+                                        .padding(14)
+                                        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+                                        .shadow(color: .black.opacity(0.04), radius: 5, y: 1)
+                                        .foregroundStyle(.primary)
+                                    }
+                                    .buttonStyle(.plain)
                                     .listRowBackground(Color.clear)
                                     .listRowSeparator(.hidden)
                                     .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
@@ -126,25 +133,10 @@ struct ConnectionsView: View {
                     }
                 }
                 ToolbarItem(placement: .topBarLeading) {
-                    HStack(spacing: 16) {
-                        Button {
-                            showingSettings = true
-                        } label: {
-                            Image(systemName: "gearshape")
-                        }
-                        Button {
-                            weeklyCheckInState.trigger()
-                        } label: {
-                            ZStack(alignment: .topTrailing) {
-                                Image(systemName: "checkmark.circle")
-                                if !homeViewModel.hasCompletedCheckInThisWeek && !viewModel.contacts.isEmpty {
-                                    Circle()
-                                        .fill(Color.accentColor)
-                                        .frame(width: 8, height: 8)
-                                        .offset(x: 3, y: -3)
-                                }
-                            }
-                        }
+                    Button {
+                        showingSettings = true
+                    } label: {
+                        Image(systemName: "gearshape")
                     }
                 }
             }
@@ -175,6 +167,25 @@ struct ConnectionsView: View {
             }
             .trackScreen("ConnectionsView", analytics: analyticsService)
         }
+    }
+}
+
+// MARK: - Helpers
+
+extension ConnectionsView {
+    fileprivate var weeklyCheckInCaptionText: String {
+        guard homeViewModel.hasCompletedCheckInThisWeek else { return "Weekly Check-In" }
+        return "This week's priority"
+    }
+
+    fileprivate var weeklyCheckInStatusText: String {
+        guard homeViewModel.hasCompletedCheckInThisWeek else {
+            return "Do your weekly check-in"
+        }
+        if let contact = homeViewModel.weeklyPriorityContact {
+            return homeViewModel.displayName(for: contact)
+        }
+        return "No priority set this week"
     }
 }
 

--- a/Eta/Views/Connections/ConnectionsView.swift
+++ b/Eta/Views/Connections/ConnectionsView.swift
@@ -5,6 +5,7 @@ struct ConnectionsView: View {
     let homeViewModel: HomeViewModel
     let settingsViewModel: SettingsViewModel
     let analyticsService: AnalyticsService
+    let weeklyCheckInState: WeeklyCheckInState
 
     @State private var showingAddSheet = false
     @State private var showingSettings = false
@@ -21,6 +22,30 @@ struct ConnectionsView: View {
                     )
                 } else {
                     List {
+                        if let contact = homeViewModel.weeklyPriorityContact {
+                            Section {
+                                HStack(spacing: 14) {
+                                    Image(systemName: "target")
+                                        .font(.title3)
+                                        .foregroundStyle(Color.accentColor)
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text("This week's priority")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                        Text(homeViewModel.displayName(for: contact))
+                                            .font(.subheadline.weight(.semibold))
+                                    }
+                                    Spacer()
+                                    Button("Clear") {
+                                        homeViewModel.saveWeeklyGoal(contactID: nil)
+                                    }
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                }
+                                .padding(.vertical, 2)
+                            }
+                        }
+
                         if !homeViewModel.friendSpotlights.isEmpty {
                             Section {
                                 ForEach(homeViewModel.friendSpotlights) { item in
@@ -101,10 +126,25 @@ struct ConnectionsView: View {
                     }
                 }
                 ToolbarItem(placement: .topBarLeading) {
-                    Button {
-                        showingSettings = true
-                    } label: {
-                        Image(systemName: "gearshape")
+                    HStack(spacing: 16) {
+                        Button {
+                            showingSettings = true
+                        } label: {
+                            Image(systemName: "gearshape")
+                        }
+                        Button {
+                            weeklyCheckInState.trigger()
+                        } label: {
+                            ZStack(alignment: .topTrailing) {
+                                Image(systemName: "checkmark.circle")
+                                if !homeViewModel.hasCompletedCheckInThisWeek {
+                                    Circle()
+                                        .fill(Color.accentColor)
+                                        .frame(width: 8, height: 8)
+                                        .offset(x: 3, y: -3)
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/Eta/Views/Connections/ConnectionsView.swift
+++ b/Eta/Views/Connections/ConnectionsView.swift
@@ -137,7 +137,7 @@ struct ConnectionsView: View {
                         } label: {
                             ZStack(alignment: .topTrailing) {
                                 Image(systemName: "checkmark.circle")
-                                if !homeViewModel.hasCompletedCheckInThisWeek {
+                                if !homeViewModel.hasCompletedCheckInThisWeek && !viewModel.contacts.isEmpty {
                                     Circle()
                                         .fill(Color.accentColor)
                                         .frame(width: 8, height: 8)

--- a/Eta/Views/Connections/ConnectionsView.swift
+++ b/Eta/Views/Connections/ConnectionsView.swift
@@ -22,7 +22,7 @@ struct ConnectionsView: View {
                     )
                 } else {
                     List {
-                        if homeViewModel.hasInitiallyLoaded {
+                        if !homeViewModel.contacts.isEmpty {
                             Section {
                                 ForEach(homeViewModel.friendSpotlights) { item in
                                     NavigationLink {

--- a/Eta/Views/Home/HomeView.swift
+++ b/Eta/Views/Home/HomeView.swift
@@ -157,6 +157,7 @@ struct HomeView: View {
     // MARK: - Action routing
 
     private func handleInsightAction(_ insight: PersonalRelationshipInsight) {
+
         switch insight.primaryAction {
         case .planActivity, .addGoal:
             showingGoalCreation = true

--- a/Eta/Views/Settings/SettingsView.swift
+++ b/Eta/Views/Settings/SettingsView.swift
@@ -92,35 +92,33 @@ struct SettingsView: View {
                 }
             ))
 
-            if viewModel.preferences.weeklyCheckInEnabled {
-                Picker("Day", selection: Binding(
-                    get: { viewModel.preferences.weeklyCheckInDay },
+            Picker("Day", selection: Binding(
+                get: { viewModel.preferences.weeklyCheckInDay },
+                set: { newValue in
+                    viewModel.preferences.weeklyCheckInDay = newValue
+                    Task { await viewModel.rescheduleWeeklyCheckIn() }
+                }
+            )) {
+                Text("Sunday").tag(1)
+                Text("Monday").tag(2)
+                Text("Tuesday").tag(3)
+                Text("Wednesday").tag(4)
+                Text("Thursday").tag(5)
+                Text("Friday").tag(6)
+                Text("Saturday").tag(7)
+            }
+
+            DatePicker(
+                "Time",
+                selection: Binding(
+                    get: { viewModel.preferences.weeklyCheckInTime },
                     set: { newValue in
-                        viewModel.preferences.weeklyCheckInDay = newValue
+                        viewModel.preferences.weeklyCheckInTime = newValue
                         Task { await viewModel.rescheduleWeeklyCheckIn() }
                     }
-                )) {
-                    Text("Sunday").tag(1)
-                    Text("Monday").tag(2)
-                    Text("Tuesday").tag(3)
-                    Text("Wednesday").tag(4)
-                    Text("Thursday").tag(5)
-                    Text("Friday").tag(6)
-                    Text("Saturday").tag(7)
-                }
-
-                DatePicker(
-                    "Time",
-                    selection: Binding(
-                        get: { viewModel.preferences.weeklyCheckInTime },
-                        set: { newValue in
-                            viewModel.preferences.weeklyCheckInTime = newValue
-                            Task { await viewModel.rescheduleWeeklyCheckIn() }
-                        }
-                    ),
-                    displayedComponents: .hourAndMinute
-                )
-            }
+                ),
+                displayedComponents: .hourAndMinute
+            )
         } header: {
             Text("Weekly Check-In")
         } footer: {

--- a/Eta/Views/Settings/SettingsView.swift
+++ b/Eta/Views/Settings/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
             Form {
                 activitiesSection
                 notificationsSection
+                weeklyCheckInSection
                 dataSection
             }
             .navigationTitle("Settings")
@@ -78,6 +79,52 @@ struct SettingsView: View {
                     displayedComponents: .hourAndMinute
                 )
             }
+        }
+    }
+
+    private var weeklyCheckInSection: some View {
+        Section {
+            Toggle("Enable Weekly Check-In", isOn: Binding(
+                get: { viewModel.preferences.weeklyCheckInEnabled },
+                set: { newValue in
+                    viewModel.preferences.weeklyCheckInEnabled = newValue
+                    Task { await viewModel.rescheduleWeeklyCheckIn() }
+                }
+            ))
+
+            if viewModel.preferences.weeklyCheckInEnabled {
+                Picker("Day", selection: Binding(
+                    get: { viewModel.preferences.weeklyCheckInDay },
+                    set: { newValue in
+                        viewModel.preferences.weeklyCheckInDay = newValue
+                        Task { await viewModel.rescheduleWeeklyCheckIn() }
+                    }
+                )) {
+                    Text("Sunday").tag(1)
+                    Text("Monday").tag(2)
+                    Text("Tuesday").tag(3)
+                    Text("Wednesday").tag(4)
+                    Text("Thursday").tag(5)
+                    Text("Friday").tag(6)
+                    Text("Saturday").tag(7)
+                }
+
+                DatePicker(
+                    "Time",
+                    selection: Binding(
+                        get: { viewModel.preferences.weeklyCheckInTime },
+                        set: { newValue in
+                            viewModel.preferences.weeklyCheckInTime = newValue
+                            Task { await viewModel.rescheduleWeeklyCheckIn() }
+                        }
+                    ),
+                    displayedComponents: .hourAndMinute
+                )
+            }
+        } header: {
+            Text("Weekly Check-In")
+        } footer: {
+            Text("A notification reminds you to review your friendships and set a weekly priority.")
         }
     }
 

--- a/Eta/Views/WeeklyCheckIn/WeeklyCheckInView.swift
+++ b/Eta/Views/WeeklyCheckIn/WeeklyCheckInView.swift
@@ -1,18 +1,13 @@
 import SwiftUI
 
-/// Full-screen sheet summarising the user's friendship activity for the current calendar week.
-///
-/// Health scores are always recomputed on appearance — no stale-cache guard — so counts
-/// reflect the calendar state at the moment the sheet opens.
-///
-/// "Seen this week" and "overdue" both use the calendar-week boundary (Sunday/Monday midnight
-/// per locale), not a rolling 7-day window, so they reset together on the same day each week.
-/// Contacts with a confirmed upcoming hangout are excluded from the overdue list.
 struct WeeklyCheckInView: View {
     let connectionsViewModel: ConnectionsViewModel
+    let homeViewModel: HomeViewModel
     let onDismiss: () -> Void
+    let onViewSuggestions: () -> Void
 
-    @State private var goalContactID: UUID? = WeeklyCheckInView.loadSavedGoal()
+    @State private var goalContactID: UUID?
+    @State private var checkInSheetContact: TrackedContact?
 
     var body: some View {
         NavigationStack {
@@ -20,10 +15,11 @@ struct WeeklyCheckInView: View {
                 VStack(alignment: .leading, spacing: 28) {
                     headerSection
                     statsSection
+                    if !upcomingThisWeek.isEmpty { upcomingSection }
                     insightsSection
-                    goalSection
-                    // Placeholder for features not yet merged (e.g. suggested activities, mood tracking)
-                    placeholderSection
+                    if !homeViewModel.activeGoals.isEmpty { goalsSection }
+                    if let warning = homeViewModel.networkConcentrationWarning { networkNudgeSection(warning) }
+                    prioritySection
                 }
                 .padding(20)
             }
@@ -33,6 +29,7 @@ struct WeeklyCheckInView: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") {
                         saveGoal()
+                        homeViewModel.markCheckInCompleted()
                         onDismiss()
                     }
                     .fontWeight(.semibold)
@@ -42,6 +39,20 @@ struct WeeklyCheckInView: View {
         .task {
             connectionsViewModel.loadContacts()
             await connectionsViewModel.loadHealthScores()
+            await homeViewModel.refresh()
+            goalContactID = homeViewModel.weeklyPriorityContactID
+        }
+        .sheet(item: $checkInSheetContact) { contact in
+            CheckInSheet(
+                displayName: homeViewModel.displayName(for: contact),
+                givenName: contact.givenName,
+                phoneNumber: contact.phoneNumber ?? "",
+                initialTemplate: homeViewModel.checkInTemplate ?? "How have you been?",
+                onSend: { message, saveAsDefault in
+                    if saveAsDefault { homeViewModel.updateCheckInTemplate(message) }
+                },
+                onDismiss: { checkInSheetContact = nil }
+            )
         }
     }
 
@@ -73,11 +84,36 @@ struct WeeklyCheckInView: View {
         }
     }
 
+    private var upcomingSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Planned this week")
+                .font(.headline)
+            ForEach(upcomingThisWeek, id: \.id) { hangout in
+                HStack(spacing: 12) {
+                    Image(systemName: "calendar.badge.checkmark")
+                        .foregroundStyle(.green)
+                        .frame(width: 20)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(hangout.contact?.givenName ?? hangout.activity)
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        Text("\(hangout.activity) · \(hangout.startDate.formatted(.dateTime.weekday(.wide).hour().minute()))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+        }
+    }
+
     private var insightsSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Who needs your attention?")
                 .font(.headline)
-
             if overdueFriends.isEmpty {
                 Text("You're all caught up! Great week.")
                     .font(.subheadline)
@@ -94,7 +130,34 @@ struct WeeklyCheckInView: View {
         }
     }
 
-    private var goalSection: some View {
+    private var goalsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Your goals")
+                .font(.headline)
+            ForEach(homeViewModel.activeGoals) { goal in
+                CheckInGoalRow(
+                    goal: goal,
+                    friendNames: homeViewModel.friendNames(for: goal)
+                )
+            }
+        }
+    }
+
+    private func networkNudgeSection(_ warning: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "person.3")
+                .foregroundStyle(.purple)
+                .font(.title3)
+            Text(warning)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var prioritySection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("This week's priority")
                 .font(.headline)
@@ -103,7 +166,7 @@ struct WeeklyCheckInView: View {
                 .foregroundStyle(.secondary)
 
             if connectionsViewModel.contacts.isEmpty {
-                Text("Add friends in the Friends tab to set a goal.")
+                Text("Add friends in the Friends tab to set a priority.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             } else {
@@ -130,22 +193,46 @@ struct WeeklyCheckInView: View {
                         }
                     }
                 }
+
+                if let selectedID = goalContactID,
+                   let contact = connectionsViewModel.contacts.first(where: { $0.id == selectedID }) {
+                    priorityActions(for: contact)
+                        .padding(.top, 4)
+                }
             }
         }
     }
 
-    private var placeholderSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("More insights coming soon")
-                .font(.headline)
-                .foregroundStyle(.secondary)
-            Text("Suggested activities, shared memories, and mood tracking will appear here as features roll out.")
-                .font(.subheadline)
-                .foregroundStyle(.tertiary)
+    private func priorityActions(for contact: TrackedContact) -> some View {
+        HStack(spacing: 10) {
+            Button {
+                saveGoal()
+                homeViewModel.markCheckInCompleted()
+                onViewSuggestions()
+            } label: {
+                Label("View suggestions", systemImage: "sparkles")
+                    .font(.subheadline.weight(.medium))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 11)
+                    .background(Color.accentColor.opacity(0.12))
+                    .foregroundStyle(Color.accentColor)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+
+            if contact.phoneNumber != nil {
+                Button {
+                    checkInSheetContact = contact
+                } label: {
+                    Label("Send check-in", systemImage: "message")
+                        .font(.subheadline.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 11)
+                        .background(Color(.secondarySystemBackground))
+                        .foregroundStyle(.primary)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+            }
         }
-        .padding(16)
-        .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
     // MARK: - Helpers
@@ -201,27 +288,18 @@ struct WeeklyCheckInView: View {
         connectionsViewModel.healthScores.values.sorted { $0.score > $1.score }
     }
 
+    private var upcomingThisWeek: [ScheduledHangout] {
+        homeViewModel.upcomingHangoutsThisWeek
+    }
+
     // MARK: - Goal persistence
 
     private func saveGoal() {
-        guard let id = goalContactID else {
-            UserDefaults.standard.removeObject(forKey: "weeklyGoalContactID")
-            return
-        }
-        let weekStart = Calendar.current.dateInterval(of: .weekOfYear, for: .now)?.start.timeIntervalSince1970 ?? 0
-        UserDefaults.standard.set(id.uuidString, forKey: "weeklyGoalContactID")
-        UserDefaults.standard.set(weekStart, forKey: "weeklyGoalWeekStart")
-    }
-
-    static func loadSavedGoal() -> UUID? {
-        let weekStart = Calendar.current.dateInterval(of: .weekOfYear, for: .now)?.start.timeIntervalSince1970 ?? 0
-        let saved = UserDefaults.standard.double(forKey: "weeklyGoalWeekStart")
-        guard abs(weekStart - saved) < 1 else { return nil }
-        return UserDefaults.standard.string(forKey: "weeklyGoalContactID").flatMap { UUID(uuidString: $0) }
+        homeViewModel.saveWeeklyGoal(contactID: goalContactID)
     }
 }
 
-// MARK: - Friend row
+// MARK: - Friend insight row
 
 private struct FriendInsightRow: View {
     let health: RelationshipHealth
@@ -259,5 +337,81 @@ private struct FriendInsightRow: View {
         if days <= 14 { return .green }
         if days <= 30 { return .yellow }
         return .red
+    }
+}
+
+// MARK: - Goal row (full-width, reuses Goal model data)
+
+private struct CheckInGoalRow: View {
+    let goal: Goal
+    let friendNames: [String]
+
+    var body: some View {
+        HStack(spacing: 14) {
+            progressRing
+            VStack(alignment: .leading, spacing: 3) {
+                Text(goal.title)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(2)
+                if !friendNames.isEmpty {
+                    Text(friendNames.joined(separator: ", "))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Text("\(goal.progress) of \(goal.target) this \(goal.cadence.displayName)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 7, height: 7)
+                Text(statusLabel)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(statusColor)
+            }
+        }
+        .padding(14)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(statusColor.opacity(0.25), lineWidth: 1)
+        )
+    }
+
+    private var progressRing: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.secondary.opacity(0.18), lineWidth: 4)
+            Circle()
+                .trim(from: 0, to: goal.progressFraction)
+                .stroke(statusColor, style: StrokeStyle(lineWidth: 4, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+                .animation(.easeInOut(duration: 0.4), value: goal.progressFraction)
+            Text("\(goal.progress)/\(goal.target)")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+        }
+        .frame(width: 38, height: 38)
+    }
+
+    private var statusColor: Color {
+        switch goal.status {
+        case .onTrack:  return Color(red: 0.2,  green: 0.7,  blue: 0.45)
+        case .atRisk:   return Color(red: 0.9,  green: 0.65, blue: 0.1)
+        case .behind:   return Color(red: 0.85, green: 0.35, blue: 0.28)
+        case .achieved: return Color(red: 0.3,  green: 0.55, blue: 0.9)
+        }
+    }
+
+    private var statusLabel: String {
+        switch goal.status {
+        case .onTrack:  return "On track"
+        case .atRisk:   return "At risk"
+        case .behind:   return "Behind"
+        case .achieved: return "Achieved"
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Enriched check-in view** — `WeeklyCheckInView` now shows real data: weekly stats (friends seen / overdue), upcoming hangouts this week, active goals with progress rings (recycled from the `Goal` model), a network concentration nudge when >65% of recent hangouts involve only 1–2 people, and a priority picker with "View suggestions" / "Send check-in" action buttons once a friend is selected.
- **Weekly priority propagation** — priority contact set in the check-in is picked first by `SuggestionService` as long as they have a non-zero health score. Dismiss escalation: 2nd dismiss → 24-hour suppression; 3rd dismiss → waived for the rest of the week. Dismiss count is week-keyed (auto-resets each new week) and resets when the priority is changed.
- **Independent check-in settings** — new section in Settings (separate from the global notifications toggle) with enable/disable, day picker (Sun–Sat), and time picker. Changes reschedule the notification immediately. Clear All Data resets priority/dismiss state but preserves the user's configured day/time.
- **Weekly check-in card in Friends tab** — a persistent card at the bottom of the "For You" section shows three states: "Do your weekly check-in" (orange, not done), the priority friend's name under "This week's priority" (done + priority set), or "No priority set this week" (done + no priority). Tapping always opens the check-in sheet. Hidden when weekly check-in is disabled in Settings; appears alongside spotlights after the first refresh. Gear icon is now alone in the leading toolbar.

## Test plan

- Open check-in — verify stats, upcoming hangouts, goals, and priority picker all show correct data
- Select a priority friend → tap Done → confirm card shows friend's name under "This week's priority"
- Reopen card → confirm check-in sheet opens with priority still selected
- Dismiss a suggestion for the priority friend twice → confirm 24h suppression; dismiss a third time → confirm waived for week
- Deselect priority in check-in + Done → confirm card shows "No priority set this week"
- Settings → Weekly Check-In → toggle off → confirm card disappears from Friends tab
- Settings → change day/time → confirm notification is rescheduled
- Settings → Clear All Data → confirm priority clears but day/time preference is preserved
- Add first friend → confirm "For You" section including check-in card appears only after the next foreground refresh, not immediately