### PR TITLE
Fix invite routing when contact has both phone and email

### DIFF
--- a/Eta/Services/InvitationManager.swift
+++ b/Eta/Services/InvitationManager.swift
@@ -76,7 +76,7 @@ final class InvitationManager {
         try modelContext.save()
 
         if supabaseService.isConfigured,
-           let receiverDeviceID = await supabaseService.lookupDeviceID(for: contactIdentifier(for: contact)),
+           let receiverDeviceID = await contactDeviceID(for: contact),
            !receiverDeviceID.isEmpty {
             let remote = RemoteInvitation(
                 id: invitation.id,
@@ -247,9 +247,14 @@ final class InvitationManager {
         notifiedRemoteIDs = notified
     }
 
-    private func contactIdentifier(for contact: TrackedContact) -> String {
-        if let phone = contact.phoneNumber { return PhoneSetupService.normalized(phone) }
-        return contact.emailAddress?.lowercased() ?? ""
+    private func contactDeviceID(for contact: TrackedContact) async -> String? {
+        if let phone = contact.phoneNumber,
+           let id = await supabaseService.lookupDeviceID(for: PhoneSetupService.normalized(phone)),
+           !id.isEmpty { return id }
+        if let email = contact.emailAddress?.lowercased(),
+           let id = await supabaseService.lookupDeviceID(for: email),
+           !id.isEmpty { return id }
+        return nil
     }
 
     private func findContact(byIdentifier identifier: String) -> TrackedContact? {


### PR DESCRIPTION
- If both phone and email were present in a contact but the contact registered their device with email, the lookup only tried phone since it saw phone was present first — the device identifier lookup would fail and it would fall back to the simulated acceptance flow
- Now, if both phone and email are present in a contact, it looks up both because it depends on what the contact used to register their device
- Replaces `contactIdentifier` (sync, returns a single String) with `contactDeviceID` (async, does the Supabase lookup itself, tries phone first then email if needed)
