### PR TITLE
Make AI suggestions time and recent-suggestion aware

### DIFF
--- a/Eta/DataProviders/DefaultContextEngine.swift
+++ b/Eta/DataProviders/DefaultContextEngine.swift
@@ -32,6 +32,6 @@ final class DefaultContextEngine: ContextEngine {
             }
         }
 
-        return PromptContext(relationshipFacts: relationshipFacts, userGoals: userGoals)
+        return PromptContext(relationshipFacts: relationshipFacts, userGoals: userGoals, previouslySuggestedActivities: [])
     }
 }

--- a/Eta/Models/PromptContext.swift
+++ b/Eta/Models/PromptContext.swift
@@ -29,6 +29,12 @@ struct PromptContext {
     var relationshipFacts: [ContextFact]
     /// User-level goals and preferences that apply regardless of the contact.
     var userGoals: [ContextFact]
+    /// The free slot that triggered this suggestion. Strategies may use it to filter
+    /// activities that are implausible at the proposed time (e.g. no dinner at 10 am).
+    var proposedTime: DateInterval?
+    /// Activities already suggested for this contact during the current app session.
+    /// Strategies should avoid repeating these.
+    var previouslySuggestedActivities: [String]
 
-    static let empty = PromptContext(relationshipFacts: [], userGoals: [])
+    static let empty = PromptContext(relationshipFacts: [], userGoals: [], previouslySuggestedActivities: [])
 }

--- a/Eta/Services/SuggestionService.swift
+++ b/Eta/Services/SuggestionService.swift
@@ -25,6 +25,10 @@ final class SuggestionService {
     /// and do not qualify for a suggestion. 7.0 corresponds to roughly one week.
     private let minimumScoreThreshold: Double = 7
 
+    /// Runtime-only log of activities suggested per contact this session.
+    /// Cleared when the app is relaunched. Keyed by TrackedContact.id.
+    private var suggestedActivities: [UUID: [String]] = [:]
+
     init(
         availabilityProvider: AvailabilityDataProvider,
         relationshipService: RelationshipService,
@@ -63,7 +67,9 @@ final class SuggestionService {
 
         // Fetch context for the chosen contact. Failures produce empty context rather
         // than aborting — a suggestion without context is better than no suggestion.
-        let context = (try? await contextEngine.query(for: topHealth.contact)) ?? .empty
+        var context = (try? await contextEngine.query(for: topHealth.contact)) ?? .empty
+        context.proposedTime = freeSlots.first
+        context.previouslySuggestedActivities = suggestedActivities[topHealth.contact.id] ?? []
 
         // Delegate activity and reason selection to the strategy.
         // On LLM failure, fall back to the rules-based strategy so the inbox isn't left empty.
@@ -84,13 +90,15 @@ final class SuggestionService {
             proposal = fallback
         }
 
-        return Suggestion(
+        let suggestion = Suggestion(
             contact: topHealth.contact,
             activityDescription: proposal.activityDescription,
             reason: proposal.reason,
             proposedTimes: freeSlots,
             generatedAt: .now
         )
+        suggestedActivities[topHealth.contact.id, default: []].append(proposal.activityDescription)
+        return suggestion
     }
 
     // MARK: - Private

--- a/Eta/Strategies/LLMActivityStrategy.swift
+++ b/Eta/Strategies/LLMActivityStrategy.swift
@@ -44,9 +44,28 @@ final class LLMActivityStrategy: ActivityStrategy {
             ? "No context available."
             : allFacts.map { "- \($0.description)" }.joined(separator: "\n")
 
+        let timeContext: String
+        if let slot = context.proposedTime {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .none
+            formatter.timeStyle = .short
+            let timeString = formatter.string(from: slot.start)
+            timeContext = "\nThe hangout is proposed for \(timeString). Suggest an activity that is plausible at that time of day (e.g. no dinner at 10am, no coffee at 9pm)."
+        } else {
+            timeContext = ""
+        }
+
+        let exclusionLines: String
+        if context.previouslySuggestedActivities.isEmpty {
+            exclusionLines = ""
+        } else {
+            let list = context.previouslySuggestedActivities.map { "- \($0)" }.joined(separator: "\n")
+            exclusionLines = "\n\nActivities already suggested — do NOT repeat these:\n\(list)"
+        }
+
         let userPrompt = """
         Context about the user's relationship with \(contactName):
-        \(factLines)
+        \(factLines)\(timeContext)\(exclusionLines)
 
         Suggest one new activity for them to do together not previously seen.
         """

--- a/Eta/Strategies/RulesActivityStrategy.swift
+++ b/Eta/Strategies/RulesActivityStrategy.swift
@@ -23,7 +23,15 @@ final class RulesActivityStrategy: ActivityStrategy {
     ) async throws -> ActivityProposal? {
         let isRemote = health.contact.isRemote
         let disliked = profileService.profile(for: health.contact).dislikedActivities
-        var candidates = Activity.allCases.filter { !disliked.contains($0) && $0.isRemote == isRemote }
+        let previouslyShown = Set(context.previouslySuggestedActivities)
+        var candidates = Activity.allCases.filter {
+            !disliked.contains($0) && $0.isRemote == isRemote && !previouslyShown.contains($0.description)
+        }
+        // Relax previously-shown constraint before the disliked constraint so the inbox never empties
+        // simply because all unseen activities have been exhausted in a single session.
+        if candidates.isEmpty {
+            candidates = Activity.allCases.filter { !disliked.contains($0) && $0.isRemote == isRemote }
+        }
         if candidates.isEmpty {
             candidates = Activity.allCases.filter { $0.isRemote == isRemote }
         }


### PR DESCRIPTION
## Summary

**Issues:** #94

Right now, the only context provided to the LLM at suggestion time are the user's preferences for which activities they have done, have enjoyed, and have not enjoyed with the target contact. This is great, but means that there may be cases where the suggestion is to "Get dinner with John", but the time of the activity is 10am -- not quite right. Additionally, I noticed that the model doesn't track which activities have been recently suggested. This, plus the fact that the temperature of the model is somewhat low, means that refreshing without accepting the activity produces the same or similar recommendations over and over again.

Instead, we should a) provide the proposed time as part of the model's context; and b) track recently given suggestions and also provide this as context to the model so that it doesn't immediately recycle the same idea.

This PR introduces these changes by extending the `PromptContext` object to include both an optional `proposedTime` field and a list of previously suggested activities in `previouslySuggested`. When a suggestion is given, its raw activity description string is appended to a running list of previous activities (per contact) in the `SuggestionService`. For proposed time, the first of the proposed times is passed to the model as context. Future work will have to rectify the case where there are multiple proposed times, and they span different times of day to the point where different activities would be appropriate.