### PR TITLE
Add, edit, delete upcoming events

### DIFF
--- a/Eta/App/MainTabView.swift
+++ b/Eta/App/MainTabView.swift
@@ -129,6 +129,7 @@ struct MainTabView: View {
             if let invite = receivedInviteState.pendingInvite {
                 ReceivedInviteSheet(
                     invite: invite,
+                    senderName: receivedInviteState.senderName,
                     onAccept: {
                         receivedInviteState.clear()
                         Task {

--- a/Eta/App/MainTabView.swift
+++ b/Eta/App/MainTabView.swift
@@ -130,6 +130,7 @@ struct MainTabView: View {
                 ReceivedInviteSheet(
                     invite: invite,
                     senderName: receivedInviteState.senderName,
+                    isEdit: receivedInviteState.isEdit,
                     onAccept: {
                         receivedInviteState.clear()
                         Task {

--- a/Eta/App/NotificationDelegate.swift
+++ b/Eta/App/NotificationDelegate.swift
@@ -76,7 +76,8 @@ final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
                     endTime: endTime,
                     status: "pending"
                 )
-                Task { @MainActor in receivedInviteState.trigger(invite: invite) }
+                let senderName = invitationManager.senderName(for: fromIdentifier)
+                Task { @MainActor in receivedInviteState.trigger(invite: invite, senderName: senderName) }
             }
             return
         }

--- a/Eta/App/NotificationDelegate.swift
+++ b/Eta/App/NotificationDelegate.swift
@@ -74,10 +74,11 @@ final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
                     activity: activity,
                     startTime: startTime,
                     endTime: endTime,
-                    status: "pending"
+                    status: "pending",
+                    previousInvitationID: userInfo["previousInvitationID"] as? String
                 )
                 let senderName = invitationManager.senderName(for: fromIdentifier)
-                Task { @MainActor in receivedInviteState.trigger(invite: invite, senderName: senderName) }
+                Task { @MainActor in receivedInviteState.trigger(invite: invite, senderName: senderName, isEdit: invite.previousInvitationID != nil) }
             }
             return
         }

--- a/Eta/EtaApp.swift
+++ b/Eta/EtaApp.swift
@@ -191,6 +191,7 @@ struct EtaApp: App {
             invitationManager: invitationManager,
             inviteService: inviteService,
             contactRepository: repository,
+            activityStrategy: activityStrategy,
             formatter: formatter
         )
         self.homeViewModel = HomeViewModel(

--- a/Eta/EtaApp.swift
+++ b/Eta/EtaApp.swift
@@ -189,6 +189,8 @@ struct EtaApp: App {
             hangoutRepository: hangoutRepository,
             pendingInviteRepository: pendingReceivedInviteRepo,
             invitationManager: invitationManager,
+            inviteService: inviteService,
+            contactRepository: repository,
             formatter: formatter
         )
         self.homeViewModel = HomeViewModel(

--- a/Eta/Models/PendingReceivedInvitation.swift
+++ b/Eta/Models/PendingReceivedInvitation.swift
@@ -6,7 +6,7 @@ import SwiftData
     var fromDevice: String
     var fromIdentifier: String
     var friendName: String
-    var senderName: String
+    var senderName: String = ""
     var activity: String
     var startTime: Date
     var endTime: Date

--- a/Eta/Models/PendingReceivedInvitation.swift
+++ b/Eta/Models/PendingReceivedInvitation.swift
@@ -6,16 +6,18 @@ import SwiftData
     var fromDevice: String
     var fromIdentifier: String
     var friendName: String
+    var senderName: String
     var activity: String
     var startTime: Date
     var endTime: Date
     var receivedAt: Date
 
-    init(remote: RemoteInvitation) {
+    init(remote: RemoteInvitation, senderName: String) {
         self.id = remote.id
         self.fromDevice = remote.fromDevice
         self.fromIdentifier = remote.fromIdentifier
         self.friendName = remote.friendName
+        self.senderName = senderName
         self.activity = remote.activity
         self.startTime = remote.startTime
         self.endTime = remote.endTime

--- a/Eta/Models/PendingReceivedInvitation.swift
+++ b/Eta/Models/PendingReceivedInvitation.swift
@@ -7,17 +7,19 @@ import SwiftData
     var fromIdentifier: String
     var friendName: String
     var senderName: String = ""
+    var isEdit: Bool = false
     var activity: String
     var startTime: Date
     var endTime: Date
     var receivedAt: Date
 
-    init(remote: RemoteInvitation, senderName: String) {
+    init(remote: RemoteInvitation, senderName: String, isEdit: Bool = false) {
         self.id = remote.id
         self.fromDevice = remote.fromDevice
         self.fromIdentifier = remote.fromIdentifier
         self.friendName = remote.friendName
         self.senderName = senderName
+        self.isEdit = isEdit
         self.activity = remote.activity
         self.startTime = remote.startTime
         self.endTime = remote.endTime
@@ -34,7 +36,8 @@ import SwiftData
             activity: activity,
             startTime: startTime,
             endTime: endTime,
-            status: "pending"
+            status: "pending",
+            previousInvitationID: nil
         )
     }
 }

--- a/Eta/Models/RemoteCancellation.swift
+++ b/Eta/Models/RemoteCancellation.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct RemoteCancellation: Codable, Identifiable {
+    let id: String
+    let fromIdentifier: String
+    let toIdentifier: String
+    let friendName: String
+    let activity: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case fromIdentifier = "from_identifier"
+        case toIdentifier   = "to_identifier"
+        case friendName     = "friend_name"
+        case activity
+    }
+}

--- a/Eta/Models/RemoteInvitation.swift
+++ b/Eta/Models/RemoteInvitation.swift
@@ -10,16 +10,18 @@ struct RemoteInvitation: Codable, Identifiable {
     let startTime: Date
     let endTime: Date
     let status: String
+    let previousInvitationID: String?
 
     enum CodingKeys: String, CodingKey {
         case id
-        case fromDevice    = "from_device"
-        case fromIdentifier = "from_identifier"
-        case toIdentifier  = "to_identifier"
-        case friendName    = "friend_name"
+        case fromDevice             = "from_device"
+        case fromIdentifier         = "from_identifier"
+        case toIdentifier           = "to_identifier"
+        case friendName             = "friend_name"
         case activity
-        case startTime     = "start_time"
-        case endTime       = "end_time"
+        case startTime              = "start_time"
+        case endTime                = "end_time"
         case status
+        case previousInvitationID   = "previous_invitation_id"
     }
 }

--- a/Eta/Models/ScheduledHangout.swift
+++ b/Eta/Models/ScheduledHangout.swift
@@ -11,6 +11,7 @@ enum InviteeResponse: String, Codable {
 @Model
 final class ScheduledHangout {
     var id: UUID
+    var invitationID: String?
     var contact: TrackedContact?
     var activity: String       // Activity.rawValue — stored as String; use resolvedActivity to get the enum
     

--- a/Eta/Services/InvitationManager.swift
+++ b/Eta/Services/InvitationManager.swift
@@ -242,9 +242,10 @@ final class InvitationManager {
             }
             guard !notified.contains(remote.id) else { continue }
             print("[Poll] scheduling notification for invite=\(remote.id)")
-            try? await notificationService.scheduleReceivedInvitationNotification(remote: remote)
+            let senderName = findContact(byIdentifier: remote.fromIdentifier)?.name ?? remote.fromIdentifier
+            try? await notificationService.scheduleReceivedInvitationNotification(remote: remote, senderName: senderName)
             if !pendingReceivedRepo.exists(id: remote.id) {
-                try? pendingReceivedRepo.add(PendingReceivedInvitation(remote: remote))
+                try? pendingReceivedRepo.add(PendingReceivedInvitation(remote: remote, senderName: senderName))
             }
             receivedInviteState?.trigger(invite: remote)
             notified.insert(remote.id)

--- a/Eta/Services/InvitationManager.swift
+++ b/Eta/Services/InvitationManager.swift
@@ -67,7 +67,8 @@ final class InvitationManager {
         friendName: String,
         scheduledTime: Date,
         endDate: Date,
-        hangoutID: UUID
+        hangoutID: UUID,
+        previousInvitationID: String? = nil
     ) async throws -> Invitation {
         try? await notificationService.requestAuthorization()
 
@@ -81,7 +82,7 @@ final class InvitationManager {
         try modelContext.save()
 
         if supabaseService.isConfigured,
-           let receiverDeviceID = await supabaseService.lookupDeviceID(for: contactIdentifier(for: contact)),
+           let receiverDeviceID = await contactDeviceID(for: contact),
            !receiverDeviceID.isEmpty {
             let remote = RemoteInvitation(
                 id: invitation.id,
@@ -92,9 +93,15 @@ final class InvitationManager {
                 activity: activityName,
                 startTime: scheduledTime,
                 endTime: endDate,
-                status: "pending"
+                status: "pending",
+                previousInvitationID: previousInvitationID
             )
             try await supabaseService.postInvitation(remote)
+            let hangoutDescriptor = FetchDescriptor<ScheduledHangout>(predicate: #Predicate { $0.id == hangoutID })
+            if let hangout = try? modelContext.fetch(hangoutDescriptor).first {
+                hangout.invitationID = invitation.id
+                try? modelContext.save()
+            }
             await notificationService.scheduleInviteSentNotification(
                 friendName: friendName,
                 activityName: activityName
@@ -169,6 +176,7 @@ final class InvitationManager {
             selectedTime: DateInterval(start: startTime, end: endTime)
         )
         hangout.inviteeResponse = .confirmed
+        hangout.invitationID = id
         modelContext.insert(hangout)
         try? modelContext.save()
         NotificationCenter.default.post(name: .scheduledHangoutsDidChange, object: nil)
@@ -180,8 +188,22 @@ final class InvitationManager {
     func pollForUpdates() async {
         async let sent: () = pollSentInvitations()
         async let received: () = pollReceivedInvitations()
-        _ = await (sent, received)
+        async let cancellations: () = pollCancellations()
+        _ = await (sent, received, cancellations)
         expireStaleHangouts()
+    }
+
+    func cancelEventByValues(contact: TrackedContact, invitationID: String, activity: String) async {
+        guard supabaseService.isConfigured,
+              let toIdentifier = await contactDeviceID(for: contact) else { return }
+        let cancellation = RemoteCancellation(
+            id: invitationID,
+            fromIdentifier: phoneSetupService.myIdentifier ?? "",
+            toIdentifier: toIdentifier,
+            friendName: contact.name,
+            activity: activity
+        )
+        try? await supabaseService.postCancellation(cancellation)
     }
 
     // MARK: - Private
@@ -247,20 +269,53 @@ final class InvitationManager {
             }
             guard !notified.contains(remote.id) else { continue }
             print("[Poll] scheduling notification for invite=\(remote.id)")
-            let senderName = findContact(byIdentifier: remote.fromIdentifier)?.name ?? remote.fromIdentifier
-            try? await notificationService.scheduleReceivedInvitationNotification(remote: remote, senderName: senderName)
-            if !pendingReceivedRepo.exists(id: remote.id) {
-                try? pendingReceivedRepo.add(PendingReceivedInvitation(remote: remote, senderName: senderName))
+            if let prevID = remote.previousInvitationID {
+                let all = (try? modelContext.fetch(FetchDescriptor<ScheduledHangout>())) ?? []
+                if let old = all.first(where: { $0.invitationID == prevID }) {
+                    notificationService.cancelHangoutReminders(for: old.id)
+                    modelContext.delete(old)
+                    try? modelContext.save()
+                }
             }
-            receivedInviteState?.trigger(invite: remote, senderName: senderName)
+            let senderName = findContact(byIdentifier: remote.fromIdentifier)?.name ?? remote.fromIdentifier
+            let isEdit = remote.previousInvitationID != nil
+            try? await notificationService.scheduleReceivedInvitationNotification(remote: remote, senderName: senderName, isEdit: isEdit)
+            if !pendingReceivedRepo.exists(id: remote.id) {
+                try? pendingReceivedRepo.add(PendingReceivedInvitation(remote: remote, senderName: senderName, isEdit: isEdit))
+            }
+            receivedInviteState?.trigger(invite: remote, senderName: senderName, isEdit: isEdit)
             notified.insert(remote.id)
         }
         notifiedRemoteIDs = notified
     }
 
-    private func contactIdentifier(for contact: TrackedContact) -> String {
-        if let phone = contact.phoneNumber { return PhoneSetupService.normalized(phone) }
-        return contact.emailAddress?.lowercased() ?? ""
+    private func pollCancellations() async {
+        guard supabaseService.isConfigured else { return }
+        guard let cancellations = try? await supabaseService.fetchCancellations() else { return }
+        for cancellation in cancellations {
+            let all = (try? modelContext.fetch(FetchDescriptor<ScheduledHangout>())) ?? []
+            if let hangout = all.first(where: { $0.invitationID == cancellation.id }) {
+                hangout.inviteeResponse = .declined
+                try? modelContext.save()
+                NotificationCenter.default.post(name: .scheduledHangoutsDidChange, object: nil)
+                let friendName = findContact(byIdentifier: cancellation.fromIdentifier)?.name ?? cancellation.fromIdentifier
+                await notificationService.scheduleEventCanceledNotification(
+                    friendName: friendName,
+                    activityName: cancellation.activity
+                )
+            }
+            await supabaseService.deleteCancellation(id: cancellation.id)
+        }
+    }
+
+    private func contactDeviceID(for contact: TrackedContact) async -> String? {
+        if let phone = contact.phoneNumber,
+           let id = await supabaseService.lookupDeviceID(for: PhoneSetupService.normalized(phone)),
+           !id.isEmpty { return id }
+        if let email = contact.emailAddress?.lowercased(),
+           let id = await supabaseService.lookupDeviceID(for: email),
+           !id.isEmpty { return id }
+        return nil
     }
 
     func senderName(for identifier: String) -> String {

--- a/Eta/Services/InvitationManager.swift
+++ b/Eta/Services/InvitationManager.swift
@@ -211,7 +211,12 @@ final class InvitationManager {
                   inv.status == .pending else { continue }
             let accepted = remote.status == "confirmed"
             try? handleInvitationResponse(invitationID: remote.id, accepted: accepted)
-            if !accepted {
+            if accepted {
+                await notificationService.scheduleInviteAcceptedNotification(
+                    friendName: remote.friendName,
+                    activityName: remote.activity
+                )
+            } else {
                 await notificationService.scheduleInviteDeclinedNotification(
                     friendName: remote.friendName,
                     activityName: remote.activity
@@ -256,6 +261,10 @@ final class InvitationManager {
     private func contactIdentifier(for contact: TrackedContact) -> String {
         if let phone = contact.phoneNumber { return PhoneSetupService.normalized(phone) }
         return contact.emailAddress?.lowercased() ?? ""
+    }
+
+    func senderName(for identifier: String) -> String {
+        findContact(byIdentifier: identifier)?.name ?? identifier
     }
 
     private func findContact(byIdentifier identifier: String) -> TrackedContact? {

--- a/Eta/Services/InvitationManager.swift
+++ b/Eta/Services/InvitationManager.swift
@@ -247,7 +247,7 @@ final class InvitationManager {
             if !pendingReceivedRepo.exists(id: remote.id) {
                 try? pendingReceivedRepo.add(PendingReceivedInvitation(remote: remote, senderName: senderName))
             }
-            receivedInviteState?.trigger(invite: remote)
+            receivedInviteState?.trigger(invite: remote, senderName: senderName)
             notified.insert(remote.id)
         }
         notifiedRemoteIDs = notified

--- a/Eta/Services/InvitationManager.swift
+++ b/Eta/Services/InvitationManager.swift
@@ -32,6 +32,11 @@ final class InvitationManager {
         self.pendingReceivedRepo = pendingReceivedRepo
     }
 
+    /// Cancels the heads-up and photo-capture notifications scheduled for a hangout.
+    func cancelHangoutReminders(for hangoutID: UUID) {
+        notificationService.cancelHangoutReminders(for: hangoutID)
+    }
+
     func fetchHangout(id: UUID) -> ScheduledHangout? {
         let descriptor = FetchDescriptor<ScheduledHangout>(
             predicate: #Predicate { $0.id == id }

--- a/Eta/Services/LocalNotificationService.swift
+++ b/Eta/Services/LocalNotificationService.swift
@@ -164,6 +164,21 @@ final class LocalNotificationService: NotificationServiceProtocol {
         try? await center.add(request)
     }
 
+    func scheduleInviteAcceptedNotification(friendName: String, activityName: String) async {
+        guard preferencesService.preferences.enableNotifications else { return }
+        let content = UNMutableNotificationContent()
+        content.title = "Invite accepted!"
+        content.body = "\(friendName) is in for \(activityName)."
+        content.sound = .default
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: "invite-accepted-\(UUID().uuidString)",
+            content: content,
+            trigger: trigger
+        )
+        try? await center.add(request)
+    }
+
     private func formattedTime(_ date: Date) -> String {
         let formatter = DateFormatter()
         formatter.timeStyle = .short

--- a/Eta/Services/LocalNotificationService.swift
+++ b/Eta/Services/LocalNotificationService.swift
@@ -107,11 +107,11 @@ final class LocalNotificationService: NotificationServiceProtocol {
         ])
     }
 
-    func scheduleReceivedInvitationNotification(remote: RemoteInvitation) async throws {
+    func scheduleReceivedInvitationNotification(remote: RemoteInvitation, senderName: String) async throws {
         guard preferencesService.preferences.enableNotifications else { return }
 
         let content = UNMutableNotificationContent()
-        content.title = "\(remote.friendName) invited you!"
+        content.title = "\(senderName) invited you!"
         content.body = "\(remote.activity) — \(formattedDateTime(remote.startTime))"
         content.sound = .default
         content.categoryIdentifier = "INVITE_RESPONSE"

--- a/Eta/Services/LocalNotificationService.swift
+++ b/Eta/Services/LocalNotificationService.swift
@@ -107,15 +107,15 @@ final class LocalNotificationService: NotificationServiceProtocol {
         ])
     }
 
-    func scheduleReceivedInvitationNotification(remote: RemoteInvitation, senderName: String) async throws {
+    func scheduleReceivedInvitationNotification(remote: RemoteInvitation, senderName: String, isEdit: Bool) async throws {
         guard preferencesService.preferences.enableNotifications else { return }
 
         let content = UNMutableNotificationContent()
-        content.title = "\(senderName) invited you!"
+        content.title = isEdit ? "\(senderName) updated the event!" : "\(senderName) invited you!"
         content.body = "\(remote.activity) — \(formattedDateTime(remote.startTime))"
         content.sound = .default
         content.categoryIdentifier = "INVITE_RESPONSE"
-        content.userInfo = [
+        var userInfo: [String: Any] = [
             "notificationType": "receivedInvite",
             "remoteInvitationID": remote.id,
             "activity": remote.activity,
@@ -124,6 +124,8 @@ final class LocalNotificationService: NotificationServiceProtocol {
             "fromIdentifier": remote.fromIdentifier,
             "friendName": remote.friendName
         ]
+        if let prev = remote.previousInvitationID { userInfo["previousInvitationID"] = prev }
+        content.userInfo = userInfo
 
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
         let request = UNNotificationRequest(
@@ -173,6 +175,21 @@ final class LocalNotificationService: NotificationServiceProtocol {
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
         let request = UNNotificationRequest(
             identifier: "invite-accepted-\(UUID().uuidString)",
+            content: content,
+            trigger: trigger
+        )
+        try? await center.add(request)
+    }
+
+    func scheduleEventCanceledNotification(friendName: String, activityName: String) async {
+        guard preferencesService.preferences.enableNotifications else { return }
+        let content = UNMutableNotificationContent()
+        content.title = "Event canceled"
+        content.body = "\(friendName) canceled \(activityName)."
+        content.sound = .default
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: "event-canceled-\(UUID().uuidString)",
             content: content,
             trigger: trigger
         )

--- a/Eta/Services/NotificationServiceProtocol.swift
+++ b/Eta/Services/NotificationServiceProtocol.swift
@@ -21,7 +21,7 @@ protocol NotificationServiceProtocol {
     func cancelHangoutReminders(for hangoutID: UUID)
 
     /// Schedule a local notification for an incoming remote invitation with Accept/Decline actions.
-    func scheduleReceivedInvitationNotification(remote: RemoteInvitation) async throws
+    func scheduleReceivedInvitationNotification(remote: RemoteInvitation, senderName: String) async throws
 
     /// Schedule a confirmation notification for the sender after an invite is posted.
     func scheduleInviteSentNotification(friendName: String, activityName: String) async

--- a/Eta/Services/NotificationServiceProtocol.swift
+++ b/Eta/Services/NotificationServiceProtocol.swift
@@ -26,6 +26,9 @@ protocol NotificationServiceProtocol {
     /// Schedule a confirmation notification for the sender after an invite is posted.
     func scheduleInviteSentNotification(friendName: String, activityName: String) async
 
+    /// Schedule a notification for the sender when the receiver accepts.
+    func scheduleInviteAcceptedNotification(friendName: String, activityName: String) async
+
     /// Schedule a notification for the sender when the receiver declines.
     func scheduleInviteDeclinedNotification(friendName: String, activityName: String) async
 }

--- a/Eta/Services/NotificationServiceProtocol.swift
+++ b/Eta/Services/NotificationServiceProtocol.swift
@@ -21,7 +21,7 @@ protocol NotificationServiceProtocol {
     func cancelHangoutReminders(for hangoutID: UUID)
 
     /// Schedule a local notification for an incoming remote invitation with Accept/Decline actions.
-    func scheduleReceivedInvitationNotification(remote: RemoteInvitation, senderName: String) async throws
+    func scheduleReceivedInvitationNotification(remote: RemoteInvitation, senderName: String, isEdit: Bool) async throws
 
     /// Schedule a confirmation notification for the sender after an invite is posted.
     func scheduleInviteSentNotification(friendName: String, activityName: String) async
@@ -31,4 +31,7 @@ protocol NotificationServiceProtocol {
 
     /// Schedule a notification for the sender when the receiver declines.
     func scheduleInviteDeclinedNotification(friendName: String, activityName: String) async
+
+    /// Schedule a notification for the receiver when the sender cancels a confirmed event.
+    func scheduleEventCanceledNotification(friendName: String, activityName: String) async
 }

--- a/Eta/Services/ReceivedInviteState.swift
+++ b/Eta/Services/ReceivedInviteState.swift
@@ -3,16 +3,19 @@ import Foundation
 @Observable final class ReceivedInviteState {
     private(set) var pendingInvite: RemoteInvitation?
     private(set) var senderName: String = ""
+    private(set) var isEdit: Bool = false
 
     var isPresented: Bool { pendingInvite != nil }
 
-    func trigger(invite: RemoteInvitation, senderName: String) {
+    func trigger(invite: RemoteInvitation, senderName: String, isEdit: Bool = false) {
         pendingInvite = invite
         self.senderName = senderName
+        self.isEdit = isEdit
     }
 
     func clear() {
         pendingInvite = nil
         senderName = ""
+        isEdit = false
     }
 }

--- a/Eta/Services/ReceivedInviteState.swift
+++ b/Eta/Services/ReceivedInviteState.swift
@@ -2,14 +2,17 @@ import Foundation
 
 @Observable final class ReceivedInviteState {
     private(set) var pendingInvite: RemoteInvitation?
+    private(set) var senderName: String = ""
 
     var isPresented: Bool { pendingInvite != nil }
 
-    func trigger(invite: RemoteInvitation) {
+    func trigger(invite: RemoteInvitation, senderName: String) {
         pendingInvite = invite
+        self.senderName = senderName
     }
 
     func clear() {
         pendingInvite = nil
+        senderName = ""
     }
 }

--- a/Eta/Services/SupabaseService.swift
+++ b/Eta/Services/SupabaseService.swift
@@ -11,24 +11,36 @@ import Foundation
 // );
 //
 // CREATE TABLE invitations (
-//   id              TEXT PRIMARY KEY,
-//   from_device     TEXT NOT NULL,
-//   from_identifier TEXT NOT NULL,      -- sender's normalized phone or email
-//   to_identifier   TEXT NOT NULL,      -- matches devices.identifier on receiver's side
+//   id                    TEXT PRIMARY KEY,
+//   from_device           TEXT NOT NULL,
+//   from_identifier       TEXT NOT NULL,      -- sender's normalized phone or email
+//   to_identifier         TEXT NOT NULL,      -- matches devices.identifier on receiver's side
+//   friend_name           TEXT NOT NULL,
+//   activity              TEXT NOT NULL,
+//   start_time            TIMESTAMPTZ NOT NULL,
+//   end_time              TIMESTAMPTZ NOT NULL,
+//   status                TEXT NOT NULL DEFAULT 'pending',
+//   previous_invitation_id TEXT,              -- set when editing an existing event
+//   created_at            TIMESTAMPTZ DEFAULT now()
+// );
+//
+// CREATE TABLE cancellations (
+//   id              TEXT PRIMARY KEY,         -- invitation ID of the original invite
+//   from_identifier TEXT NOT NULL,
+//   to_identifier   TEXT NOT NULL,
 //   friend_name     TEXT NOT NULL,
 //   activity        TEXT NOT NULL,
-//   start_time      TIMESTAMPTZ NOT NULL,
-//   end_time        TIMESTAMPTZ NOT NULL,
-//   status          TEXT NOT NULL DEFAULT 'pending',
 //   created_at      TIMESTAMPTZ DEFAULT now()
 // );
 //
-// Enable Row Level Security and add permissive policies for both tables:
+// Enable Row Level Security and add permissive policies for all tables:
 //
-//   ALTER TABLE devices    ENABLE ROW LEVEL SECURITY;
-//   ALTER TABLE invitations ENABLE ROW LEVEL SECURITY;
-//   CREATE POLICY "allow all" ON devices    FOR ALL USING (true) WITH CHECK (true);
-//   CREATE POLICY "allow all" ON invitations FOR ALL USING (true) WITH CHECK (true);
+//   ALTER TABLE devices       ENABLE ROW LEVEL SECURITY;
+//   ALTER TABLE invitations   ENABLE ROW LEVEL SECURITY;
+//   ALTER TABLE cancellations ENABLE ROW LEVEL SECURITY;
+//   CREATE POLICY "allow all" ON devices       FOR ALL USING (true) WITH CHECK (true);
+//   CREATE POLICY "allow all" ON invitations   FOR ALL USING (true) WITH CHECK (true);
+//   CREATE POLICY "allow all" ON cancellations FOR ALL USING (true) WITH CHECK (true);
 
 final class SupabaseService {
     private let baseURL: String
@@ -99,7 +111,7 @@ final class SupabaseService {
     // MARK: - Invitations
 
     func postInvitation(_ inv: RemoteInvitation) async throws {
-        let body: [String: Any] = [
+        var body: [String: Any] = [
             "id": inv.id,
             "from_device": inv.fromDevice,
             "from_identifier": inv.fromIdentifier,
@@ -110,7 +122,32 @@ final class SupabaseService {
             "end_time": iso(inv.endTime),
             "status": "pending"
         ]
+        if let prev = inv.previousInvitationID { body["previous_invitation_id"] = prev }
         try await request(path: "/rest/v1/invitations", method: "POST", body: body)
+    }
+
+    // MARK: - Cancellations
+
+    func postCancellation(_ c: RemoteCancellation) async throws {
+        let body: [String: Any] = [
+            "id": c.id,
+            "from_identifier": c.fromIdentifier,
+            "to_identifier": c.toIdentifier,
+            "friend_name": c.friendName,
+            "activity": c.activity
+        ]
+        try await request(path: "/rest/v1/cancellations", method: "POST", body: body)
+    }
+
+    func fetchCancellations() async throws -> [RemoteCancellation] {
+        let encoded = urlEncoded(deviceID)
+        let path = "/rest/v1/cancellations?to_identifier=eq.\(encoded)&select=*"
+        let data = try await request(path: path, method: "GET")
+        return (try? Self.decoder.decode([RemoteCancellation].self, from: data)) ?? []
+    }
+
+    func deleteCancellation(id: String) async {
+        try? await request(path: "/rest/v1/cancellations?id=eq.\(id)", method: "DELETE")
     }
 
     /// Returns invitations sent to this device that are still pending.

--- a/Eta/ViewModels/AvailabilityViewModel.swift
+++ b/Eta/ViewModels/AvailabilityViewModel.swift
@@ -3,17 +3,25 @@
 import Foundation
 import Observation
 
+struct HangoutSlot {
+    let startDate: Date
+    let endDate: Date
+    let status: HangoutStatus
+    let activity: String
+    let contactFirstName: String?
+}
+
 /// Drives the Availability tab by combining saved free time, scheduled hangouts, and duration settings.
 @Observable
 final class AvailabilityViewModel {
 
     /// All saved free-time blocks, sorted by start time after loading or mutation.
     var blocks: [AvailabilityBlock] = []
-    /// Upcoming or in-progress hangouts that should appear as scheduled time.
-    var scheduledHangouts: [ScheduledHangout] = []
+    /// Upcoming hangouts as value-type snapshots — never holds live SwiftData references.
+    var scheduledHangouts: [HangoutSlot] = []
     /// User-selected hangout length in minutes, constrained to 15-minute increments.
     var activityDurationMinutes: Int
-    
+
     private let repository: AvailabilityRepository
     private let hangoutRepository: ScheduledHangoutRepository
     private let activityDurationSettings: ActivityDurationSettings
@@ -67,6 +75,21 @@ final class AvailabilityViewModel {
         do {
             scheduledHangouts = try hangoutRepository.fetchUpcoming()
                 .sorted { $0.startDate < $1.startDate }
+                .map { h in
+                    let firstName: String?
+                    if let contact = h.contact {
+                        firstName = contact.givenName.isEmpty ? contact.name : contact.givenName
+                    } else {
+                        firstName = nil
+                    }
+                    return HangoutSlot(
+                        startDate: h.startDate,
+                        endDate: h.endDate,
+                        status: h.status,
+                        activity: h.activity,
+                        contactFirstName: firstName
+                    )
+                }
         } catch {
             scheduledHangouts = []
         }
@@ -123,7 +146,7 @@ final class AvailabilityViewModel {
         blocks.removeAll { $0.id == id }
         saveBlocks()
     }
-    
+
     /// Returns whether the daily availability prompt should still be shown.
     func shouldShowPrompt(for date: Date) -> Bool {
         !tracker.hasProvidedAvailability(for: date)
@@ -142,23 +165,19 @@ final class AvailabilityViewModel {
     }
 
     /// Returns scheduled hangouts whose start date falls on the requested day.
-    func scheduledHangouts(on date: Date) -> [ScheduledHangout] {
+    func scheduledHangouts(on date: Date) -> [HangoutSlot] {
         scheduledHangouts.filter {
             Calendar.current.isDate($0.startDate, inSameDayAs: date)
         }
     }
 
     /// Returns true when a free-time block overlaps any scheduled hangout in the supplied list.
-    func isBlocked(
-            _ block: AvailabilityBlock,
-            scheduled: [ScheduledHangout]
-        ) -> Bool {
-
-            scheduled.contains {
-                $0.startDate < block.endTime &&
-                $0.endDate > block.startTime
-            }
+    func isBlocked(_ block: AvailabilityBlock, scheduled: [HangoutSlot]) -> Bool {
+        scheduled.contains {
+            $0.startDate < block.endTime &&
+            $0.endDate > block.startTime
         }
+    }
 
     /// Returns true when any saved free-time block overlaps the interval.
     func isFree(during interval: DateInterval) -> Bool {
@@ -185,19 +204,11 @@ final class AvailabilityViewModel {
                 $0.startDate < interval.end &&
                 $0.endDate > interval.start
             }
-            .map { hangout in
-                let firstName: String?
-                if let contact = hangout.contact {
-                    firstName = contact.givenName.isEmpty ? contact.name : contact.givenName
-                } else {
-                    firstName = nil
+            .map { slot in
+                if let firstName = slot.contactFirstName, !firstName.isEmpty {
+                    return "\(slot.activity) with \(firstName)"
                 }
-
-                if let firstName, !firstName.isEmpty {
-                    return "\(hangout.activity) with \(firstName)"
-                }
-
-                return hangout.activity
+                return slot.activity
             }
     }
 

--- a/Eta/ViewModels/UpcomingEventsViewModel.swift
+++ b/Eta/ViewModels/UpcomingEventsViewModel.swift
@@ -31,6 +31,7 @@ final class UpcomingEventsViewModel {
     private let invitationManager: InvitationManager
     private let inviteService: InviteService
     private let contactRepository: ContactRepository
+    private let activityStrategy: LLMActivityStrategy
     private let formatter: ContactFormatter
 
     init(
@@ -39,6 +40,7 @@ final class UpcomingEventsViewModel {
         invitationManager: InvitationManager,
         inviteService: InviteService,
         contactRepository: ContactRepository,
+        activityStrategy: LLMActivityStrategy,
         formatter: ContactFormatter
     ) {
         self.hangoutRepository = hangoutRepository
@@ -46,6 +48,7 @@ final class UpcomingEventsViewModel {
         self.invitationManager = invitationManager
         self.inviteService = inviteService
         self.contactRepository = contactRepository
+        self.activityStrategy = activityStrategy
         self.formatter = formatter
     }
 
@@ -125,5 +128,30 @@ final class UpcomingEventsViewModel {
         invitationManager.cancelHangoutReminders(for: hangout.id)
         try? hangoutRepository.remove(hangout)
         Task { await refresh() }
+    }
+
+    /// Calls LLMActivityStrategy.propose() for the given contact and proposed time.
+    /// Builds a minimal RelationshipHealth (no history) and a time-enriched PromptContext.
+    /// Throws if the strategy throws — callers should surface a failure indicator, not crash.
+    func suggestActivity(for contact: TrackedContact, proposedTime: DateInterval) async throws -> String? {
+        let health = RelationshipHealth(
+            contact: contact,
+            lastHangoutDate: nil,
+            lastHangoutTitle: nil,
+            hangoutCount: 0,
+            score: 0,
+            upcomingHangout: nil
+        )
+        let timeString = proposedTime.start.formatted(.dateTime.weekday(.wide).hour(.defaultDigits(amPM: .abbreviated)))
+        let context = PromptContext(
+            relationshipFacts: [
+                ContextFact(
+                    description: "The user wants to meet on \(timeString)",
+                    source: .onboardingPreferences
+                )
+            ],
+            userGoals: []
+        )
+        return try await activityStrategy.propose(for: health, context: context)?.activityDescription
     }
 }

--- a/Eta/ViewModels/UpcomingEventsViewModel.swift
+++ b/Eta/ViewModels/UpcomingEventsViewModel.swift
@@ -53,29 +53,22 @@ final class UpcomingEventsViewModel {
     }
 
     func refresh() async {
-        do {
-            let hangouts = try hangoutRepository.fetchAll()
-            let startOfToday = Calendar.current.startOfDay(for: .now)
-
-            let items: [HangoutDisplayItem] = hangouts
-                .filter { $0.contact != nil }
-                .sorted { $0.startDate < $1.startDate }
-                .map { hangout in
-                    let name = hangout.contact.map { formatter.displayName(for: $0) } ?? "Unknown"
-                    return HangoutDisplayItem(hangout: hangout, contactName: name)
-                }
-
-            allItems = items
-            upcomingItems = items.filter { $0.hangout.startDate >= startOfToday }
-        } catch {
-            // SwiftData fetch failed; leave existing data in place.
-        }
-
+        reloadItems()
         pendingInvites = ((try? pendingInviteRepository.fetchAll()) ?? [])
             .filter { $0.endTime > .now }
             .sorted { $0.startTime < $1.startTime }
-
         contacts = (try? contactRepository.fetchAll()) ?? []
+    }
+
+    private func reloadItems() {
+        guard let hangouts = try? hangoutRepository.fetchAll() else { return }
+        let startOfToday = Calendar.current.startOfDay(for: .now)
+        let items: [HangoutDisplayItem] = hangouts
+            .filter { $0.contact != nil }
+            .sorted { $0.startDate < $1.startDate }
+            .map { HangoutDisplayItem(hangout: $0, contactName: formatter.displayName(for: $0.contact!)) }
+        allItems = items
+        upcomingItems = items.filter { $0.hangout.startDate >= startOfToday }
     }
 
     func respond(to invite: PendingReceivedInvitation, accepted: Bool) async {
@@ -93,7 +86,7 @@ final class UpcomingEventsViewModel {
     // MARK: - CRUD
 
     /// Books a new hangout and sends an invitation via InvitationManager.
-    func addEvent(contact: TrackedContact, activity: String, interval: DateInterval) async {
+    func addEvent(contact: TrackedContact, activity: String, interval: DateInterval, previousInvitationID: String? = nil) async {
         let suggestion = Suggestion(
             contact: contact,
             activityDescription: activity,
@@ -109,7 +102,8 @@ final class UpcomingEventsViewModel {
             friendName: friendName,
             scheduledTime: interval.start,
             endDate: interval.end,
-            hangoutID: hangoutID
+            hangoutID: hangoutID,
+            previousInvitationID: previousInvitationID
         )
         await refresh()
     }
@@ -118,16 +112,28 @@ final class UpcomingEventsViewModel {
     /// The contact cannot be changed — only the activity, date, and duration.
     func editEvent(_ hangout: ScheduledHangout, activity: String, interval: DateInterval) async {
         guard let contact = hangout.contact else { return }
+        let previousInvitationID = hangout.invitationID
         invitationManager.cancelHangoutReminders(for: hangout.id)
         try? hangoutRepository.remove(hangout)
-        await addEvent(contact: contact, activity: activity, interval: interval)
+        reloadItems()
+        await addEvent(contact: contact, activity: activity, interval: interval, previousInvitationID: previousInvitationID)
     }
 
     /// Removes the hangout and cancels its associated notifications.
+    /// If the event is confirmed and has a Supabase-backed invitation, notifies the other user.
     func deleteEvent(_ hangout: ScheduledHangout) {
         invitationManager.cancelHangoutReminders(for: hangout.id)
+        let isConfirmedBackend = hangout.inviteeResponse == .confirmed && hangout.invitationID != nil
+        let contact = hangout.contact
+        let invitationID = hangout.invitationID
+        let activity = hangout.activity
         try? hangoutRepository.remove(hangout)
-        Task { await refresh() }
+        reloadItems()
+        Task {
+            if isConfirmedBackend, let contact, let invitationID {
+                await invitationManager.cancelEventByValues(contact: contact, invitationID: invitationID, activity: activity)
+            }
+        }
     }
 
     /// Calls LLMActivityStrategy.propose() for the given contact and proposed time.

--- a/Eta/ViewModels/UpcomingEventsViewModel.swift
+++ b/Eta/ViewModels/UpcomingEventsViewModel.swift
@@ -23,20 +23,29 @@ final class UpcomingEventsViewModel {
     /// Invitations received that are still awaiting a response, sorted soonest first.
     private(set) var pendingInvites: [PendingReceivedInvitation] = []
 
+    /// All tracked contacts — used to populate the add-event contact picker.
+    private(set) var contacts: [TrackedContact] = []
+
     private let hangoutRepository: ScheduledHangoutRepository
     private let pendingInviteRepository: PendingReceivedInvitationRepository
     private let invitationManager: InvitationManager
+    private let inviteService: InviteService
+    private let contactRepository: ContactRepository
     private let formatter: ContactFormatter
 
     init(
         hangoutRepository: ScheduledHangoutRepository,
         pendingInviteRepository: PendingReceivedInvitationRepository,
         invitationManager: InvitationManager,
+        inviteService: InviteService,
+        contactRepository: ContactRepository,
         formatter: ContactFormatter
     ) {
         self.hangoutRepository = hangoutRepository
         self.pendingInviteRepository = pendingInviteRepository
         self.invitationManager = invitationManager
+        self.inviteService = inviteService
+        self.contactRepository = contactRepository
         self.formatter = formatter
     }
 
@@ -62,6 +71,8 @@ final class UpcomingEventsViewModel {
         pendingInvites = ((try? pendingInviteRepository.fetchAll()) ?? [])
             .filter { $0.endTime > .now }
             .sorted { $0.startTime < $1.startTime }
+
+        contacts = (try? contactRepository.fetchAll()) ?? []
     }
 
     func respond(to invite: PendingReceivedInvitation, accepted: Bool) async {
@@ -74,5 +85,45 @@ final class UpcomingEventsViewModel {
             fromIdentifier: invite.fromIdentifier
         )
         await refresh()
+    }
+
+    // MARK: - CRUD
+
+    /// Books a new hangout and sends an invitation via InvitationManager.
+    func addEvent(contact: TrackedContact, activity: String, interval: DateInterval) async {
+        let suggestion = Suggestion(
+            contact: contact,
+            activityDescription: activity,
+            reason: "Manually scheduled",
+            proposedTimes: [interval],
+            generatedAt: .now
+        )
+        let hangoutID = inviteService.book(suggestion: suggestion)
+        let friendName = formatter.displayName(for: contact)
+        _ = try? await invitationManager.acceptSuggestion(
+            contact: contact,
+            activityName: activity,
+            friendName: friendName,
+            scheduledTime: interval.start,
+            endDate: interval.end,
+            hangoutID: hangoutID
+        )
+        await refresh()
+    }
+
+    /// Cancels the existing hangout and schedules a replacement with updated details.
+    /// The contact cannot be changed — only the activity, date, and duration.
+    func editEvent(_ hangout: ScheduledHangout, activity: String, interval: DateInterval) async {
+        guard let contact = hangout.contact else { return }
+        invitationManager.cancelHangoutReminders(for: hangout.id)
+        try? hangoutRepository.remove(hangout)
+        await addEvent(contact: contact, activity: activity, interval: interval)
+    }
+
+    /// Removes the hangout and cancels its associated notifications.
+    func deleteEvent(_ hangout: ScheduledHangout) {
+        invitationManager.cancelHangoutReminders(for: hangout.id)
+        try? hangoutRepository.remove(hangout)
+        Task { await refresh() }
     }
 }

--- a/Eta/Views/Reminders/ReceivedInviteSheet.swift
+++ b/Eta/Views/Reminders/ReceivedInviteSheet.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ReceivedInviteSheet: View {
     let invite: RemoteInvitation
     let senderName: String
+    let isEdit: Bool
     let onAccept: () -> Void
     let onDecline: () -> Void
     @Environment(\.dismiss) private var dismiss
@@ -12,7 +13,7 @@ struct ReceivedInviteSheet: View {
             Spacer()
 
             VStack(spacing: 8) {
-                Text("\(senderName) invited you!")
+                Text(isEdit ? "\(senderName) updated the event!" : "\(senderName) invited you!")
                     .font(.title2)
                     .fontWeight(.semibold)
                     .multilineTextAlignment(.center)

--- a/Eta/Views/Reminders/ReceivedInviteSheet.swift
+++ b/Eta/Views/Reminders/ReceivedInviteSheet.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ReceivedInviteSheet: View {
     let invite: RemoteInvitation
+    let senderName: String
     let onAccept: () -> Void
     let onDecline: () -> Void
     @Environment(\.dismiss) private var dismiss
@@ -11,7 +12,7 @@ struct ReceivedInviteSheet: View {
             Spacer()
 
             VStack(spacing: 8) {
-                Text("\(invite.friendName) invited you!")
+                Text("\(senderName) invited you!")
                     .font(.title2)
                     .fontWeight(.semibold)
                     .multilineTextAlignment(.center)

--- a/Eta/Views/UpcomingEvents/AddEditEventSheet.swift
+++ b/Eta/Views/UpcomingEvents/AddEditEventSheet.swift
@@ -232,9 +232,9 @@ struct AddEditEventSheet: View {
             }
         case .edit(let item):
             guard let contact = item.hangout.contact else { return }
+            dismiss()
             Task {
                 await onSave(contact, activityValue, interval)
-                dismiss()
             }
         }
     }

--- a/Eta/Views/UpcomingEvents/AddEditEventSheet.swift
+++ b/Eta/Views/UpcomingEvents/AddEditEventSheet.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+struct AddEditEventSheet: View {
+    enum Mode {
+        case add([TrackedContact])
+        case edit(HangoutDisplayItem)
+    }
+
+    let mode: Mode
+    let onSave: (TrackedContact, String, DateInterval) async -> Void
+
+    @State private var selectedContactID: UUID?
+    @State private var selectedActivity: Activity = .coffee
+    @State private var startDate: Date = .now
+    @State private var durationHours: Double = 1.0
+
+    @Environment(\.dismiss) private var dismiss
+
+    private static let availableDurations: [Double] = [0.5, 1.0, 1.5, 2.0, 3.0]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                contactSection
+                activitySection
+                timeSection
+            }
+            .navigationTitle(isEditing ? "Edit Event" : "New Event")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                        .disabled(!canSave)
+                }
+            }
+        }
+        .onAppear { configure() }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var contactSection: some View {
+        Section("With") {
+            switch mode {
+            case .add(let contacts):
+                if contacts.isEmpty {
+                    Text("Add friends first to schedule events")
+                        .foregroundStyle(.secondary)
+                } else {
+                    Picker("Friend", selection: $selectedContactID) {
+                        Text("Select a friend").tag(nil as UUID?)
+                        ForEach(contacts) { contact in
+                            Text(contact.name).tag(contact.id as UUID?)
+                        }
+                    }
+                }
+            case .edit(let item):
+                LabeledContent("Friend", value: item.contactName)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var activitySection: some View {
+        Section("Activity") {
+            Picker("Activity", selection: $selectedActivity) {
+                ForEach(Activity.allCases) { activity in
+                    Text(activity.rawValue).tag(activity)
+                }
+            }
+            .pickerStyle(.menu)
+        }
+    }
+
+    private var timeSection: some View {
+        Section("When") {
+            DatePicker(
+                "Start",
+                selection: $startDate,
+                in: Date.now...,
+                displayedComponents: [.date, .hourAndMinute]
+            )
+            Picker("Duration", selection: $durationHours) {
+                Text("30 min").tag(0.5)
+                Text("1 hour").tag(1.0)
+                Text("1.5 hours").tag(1.5)
+                Text("2 hours").tag(2.0)
+                Text("3 hours").tag(3.0)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var isEditing: Bool {
+        if case .edit = mode { return true }
+        return false
+    }
+
+    private var canSave: Bool {
+        if case .add = mode { return selectedContactID != nil }
+        return true
+    }
+
+    private func configure() {
+        switch mode {
+        case .add:
+            startDate = nextRoundHour()
+        case .edit(let item):
+            selectedActivity = item.hangout.resolvedActivity ?? .coffee
+            let eventStart = item.hangout.startDate
+            startDate = eventStart > .now ? eventStart : nextRoundHour()
+            let durationSeconds = item.hangout.endDate.timeIntervalSince(item.hangout.startDate)
+            let hours = durationSeconds / 3600
+            durationHours = Self.availableDurations.min(by: { abs($0 - hours) < abs($1 - hours) }) ?? 1.0
+        }
+    }
+
+    private func nextRoundHour() -> Date {
+        var components = Calendar.current.dateComponents([.year, .month, .day, .hour], from: .now)
+        components.hour = (components.hour ?? 0) + 1
+        components.minute = 0
+        return Calendar.current.date(from: components) ?? .now.addingTimeInterval(3600)
+    }
+
+    private func save() {
+        let interval = DateInterval(start: startDate, duration: durationHours * 3600)
+        switch mode {
+        case .add(let contacts):
+            guard let id = selectedContactID,
+                  let contact = contacts.first(where: { $0.id == id }) else { return }
+            Task {
+                await onSave(contact, selectedActivity.rawValue, interval)
+                dismiss()
+            }
+        case .edit(let item):
+            guard let contact = item.hangout.contact else { return }
+            Task {
+                await onSave(contact, selectedActivity.rawValue, interval)
+                dismiss()
+            }
+        }
+    }
+}

--- a/Eta/Views/UpcomingEvents/AddEditEventSheet.swift
+++ b/Eta/Views/UpcomingEvents/AddEditEventSheet.swift
@@ -6,11 +6,21 @@ struct AddEditEventSheet: View {
         case edit(HangoutDisplayItem)
     }
 
+    private enum ActivityInputMode: Hashable {
+        case preset
+        case custom
+    }
+
     let mode: Mode
     let onSave: (TrackedContact, String, DateInterval) async -> Void
+    let onSuggestActivity: (TrackedContact, DateInterval) async throws -> String?
 
     @State private var selectedContactID: UUID?
-    @State private var selectedActivity: Activity = .coffee
+    @State private var activityInputMode: ActivityInputMode = .preset
+    @State private var selectedPreset: Activity = .coffee
+    @State private var customText: String = ""
+    @State private var isGeneratingAI: Bool = false
+    @State private var aiGenerationFailed: Bool = false
     @State private var startDate: Date = .now
     @State private var durationHours: Double = 1.0
 
@@ -67,12 +77,44 @@ struct AddEditEventSheet: View {
 
     private var activitySection: some View {
         Section("Activity") {
-            Picker("Activity", selection: $selectedActivity) {
-                ForEach(Activity.allCases) { activity in
-                    Text(activity.rawValue).tag(activity)
+            Picker("Type", selection: $activityInputMode) {
+                Text("Preset").tag(ActivityInputMode.preset)
+                Text("Custom").tag(ActivityInputMode.custom)
+            }
+            .pickerStyle(.segmented)
+
+            if activityInputMode == .preset {
+                Picker("Activity", selection: $selectedPreset) {
+                    ForEach(Activity.allCases) { activity in
+                        Text(activity.rawValue).tag(activity)
+                    }
+                }
+                .pickerStyle(.menu)
+            } else {
+                HStack {
+                    TextField("e.g. Go bouldering", text: $customText)
+                    if isGeneratingAI {
+                        ProgressView()
+                            .controlSize(.small)
+                            .padding(.leading, 4)
+                    } else {
+                        Button {
+                            generateAISuggestion()
+                        } label: {
+                            Image(systemName: "sparkles")
+                                .foregroundColor(aiSuggestDisabled ? .secondary : .blue)
+                        }
+                        .buttonStyle(.borderless)
+                        .disabled(aiSuggestDisabled)
+                        .help("Suggest an activity with AI")
+                    }
+                }
+                if aiGenerationFailed {
+                    Text("AI suggestion unavailable")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             }
-            .pickerStyle(.menu)
         }
     }
 
@@ -94,16 +136,61 @@ struct AddEditEventSheet: View {
         }
     }
 
-    // MARK: - Helpers
+    // MARK: - Computed helpers
 
     private var isEditing: Bool {
         if case .edit = mode { return true }
         return false
     }
 
+    /// The contact to use for AI suggestion generation.
+    private var currentContact: TrackedContact? {
+        switch mode {
+        case .add(let contacts):
+            guard let id = selectedContactID else { return nil }
+            return contacts.first { $0.id == id }
+        case .edit(let item):
+            return item.hangout.contact
+        }
+    }
+
+    private var aiSuggestDisabled: Bool {
+        currentContact == nil || aiGenerationFailed
+    }
+
+    private var activityValue: String {
+        switch activityInputMode {
+        case .preset: return selectedPreset.rawValue
+        case .custom: return customText.trimmingCharacters(in: .whitespaces)
+        }
+    }
+
     private var canSave: Bool {
-        if case .add = mode { return selectedContactID != nil }
-        return true
+        let activityValid: Bool = activityInputMode == .preset
+            || !customText.trimmingCharacters(in: .whitespaces).isEmpty
+        if case .add = mode { return selectedContactID != nil && activityValid }
+        return activityValid
+    }
+
+    // MARK: - Actions
+
+    private func generateAISuggestion() {
+        guard let contact = currentContact else { return }
+        let proposedTime = DateInterval(start: startDate, duration: durationHours * 3600)
+        isGeneratingAI = true
+        Task {
+            do {
+                let suggestion = try await onSuggestActivity(contact, proposedTime)
+                if let suggestion, !suggestion.isEmpty {
+                    customText = suggestion
+                } else {
+                    aiGenerationFailed = true
+                }
+            } catch {
+                aiGenerationFailed = true
+            }
+            isGeneratingAI = false
+        }
     }
 
     private func configure() {
@@ -111,7 +198,13 @@ struct AddEditEventSheet: View {
         case .add:
             startDate = nextRoundHour()
         case .edit(let item):
-            selectedActivity = item.hangout.resolvedActivity ?? .coffee
+            if let preset = item.hangout.resolvedActivity {
+                activityInputMode = .preset
+                selectedPreset = preset
+            } else {
+                activityInputMode = .custom
+                customText = item.hangout.activity
+            }
             let eventStart = item.hangout.startDate
             startDate = eventStart > .now ? eventStart : nextRoundHour()
             let durationSeconds = item.hangout.endDate.timeIntervalSince(item.hangout.startDate)
@@ -134,13 +227,13 @@ struct AddEditEventSheet: View {
             guard let id = selectedContactID,
                   let contact = contacts.first(where: { $0.id == id }) else { return }
             Task {
-                await onSave(contact, selectedActivity.rawValue, interval)
+                await onSave(contact, activityValue, interval)
                 dismiss()
             }
         case .edit(let item):
             guard let contact = item.hangout.contact else { return }
             Task {
-                await onSave(contact, selectedActivity.rawValue, interval)
+                await onSave(contact, activityValue, interval)
                 dismiss()
             }
         }

--- a/Eta/Views/UpcomingEvents/ReceivedInviteCard.swift
+++ b/Eta/Views/UpcomingEvents/ReceivedInviteCard.swift
@@ -8,7 +8,7 @@ struct ReceivedInviteCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("\(invite.senderName) invited you")
+                Text(invite.isEdit ? "\(invite.senderName) updated the event" : "\(invite.senderName) invited you")
                     .font(.headline)
                 Text(invite.activity)
                     .font(.subheadline)

--- a/Eta/Views/UpcomingEvents/ReceivedInviteCard.swift
+++ b/Eta/Views/UpcomingEvents/ReceivedInviteCard.swift
@@ -8,7 +8,7 @@ struct ReceivedInviteCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("\(invite.friendName) invited you")
+                Text("\(invite.senderName) invited you")
                     .font(.headline)
                 Text(invite.activity)
                     .font(.subheadline)

--- a/Eta/Views/UpcomingEvents/UpcomingEventCardView.swift
+++ b/Eta/Views/UpcomingEvents/UpcomingEventCardView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct UpcomingEventCardView: View {
     let item: HangoutDisplayItem
     let photoRepository: ActivityPhotoRepository
+    var onEdit: (() -> Void)? = nil
+    var onDelete: (() -> Void)? = nil
 
     @State private var showingPhotoSheet = false
 
@@ -33,6 +35,18 @@ struct UpcomingEventCardView: View {
         }
         .padding()
         .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+        .contextMenu {
+            if let onEdit {
+                Button { onEdit() } label: {
+                    Label("Edit", systemImage: "pencil")
+                }
+            }
+            if let onDelete {
+                Button(role: .destructive) { onDelete() } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+        }
         .sheet(isPresented: $showingPhotoSheet) {
             let activity = item.hangout.resolvedActivity ?? .walk
             let hangoutID = item.hangout.id

--- a/Eta/Views/UpcomingEvents/UpcomingEventCardView.swift
+++ b/Eta/Views/UpcomingEvents/UpcomingEventCardView.swift
@@ -36,7 +36,7 @@ struct UpcomingEventCardView: View {
         .padding()
         .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
         .contextMenu {
-            if let onEdit {
+            if let onEdit, item.hangout.status != .canceled {
                 Button { onEdit() } label: {
                     Label("Edit", systemImage: "pencil")
                 }

--- a/Eta/Views/UpcomingEvents/UpcomingEventsDashboard.swift
+++ b/Eta/Views/UpcomingEvents/UpcomingEventsDashboard.swift
@@ -78,6 +78,9 @@ struct UpcomingEventsDashboard: View {
                 mode: .add(viewModel.contacts),
                 onSave: { contact, activity, interval in
                     await viewModel.addEvent(contact: contact, activity: activity, interval: interval)
+                },
+                onSuggestActivity: { contact, proposedTime in
+                    try await viewModel.suggestActivity(for: contact, proposedTime: proposedTime)
                 }
             )
         }
@@ -86,6 +89,9 @@ struct UpcomingEventsDashboard: View {
                 mode: .edit(item),
                 onSave: { _, activity, interval in
                     await viewModel.editEvent(item.hangout, activity: activity, interval: interval)
+                },
+                onSuggestActivity: { contact, proposedTime in
+                    try await viewModel.suggestActivity(for: contact, proposedTime: proposedTime)
                 }
             )
         }

--- a/Eta/Views/UpcomingEvents/UpcomingEventsDashboard.swift
+++ b/Eta/Views/UpcomingEvents/UpcomingEventsDashboard.swift
@@ -5,6 +5,9 @@ struct UpcomingEventsDashboard: View {
     let photoRepository: ActivityPhotoRepository
     @Environment(\.scenePhase) private var scenePhase
 
+    @State private var showingAddSheet = false
+    @State private var editingItem: HangoutDisplayItem? = nil
+
     var body: some View {
         NavigationStack {
             Group {
@@ -26,8 +29,13 @@ struct UpcomingEventsDashboard: View {
                                 .padding(.horizontal)
                             }
                             ForEach(viewModel.upcomingItems) { item in
-                                UpcomingEventCardView(item: item, photoRepository: photoRepository)
-                                    .padding(.horizontal)
+                                UpcomingEventCardView(
+                                    item: item,
+                                    photoRepository: photoRepository,
+                                    onEdit: { editingItem = item },
+                                    onDelete: { viewModel.deleteEvent(item.hangout) }
+                                )
+                                .padding(.horizontal)
                             }
                         }
                         .padding(.vertical, 12)
@@ -37,12 +45,19 @@ struct UpcomingEventsDashboard: View {
             }
             .navigationTitle("Events")
             .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: .topBarLeading) {
                     NavigationLink {
                         EventHistoryView(items: viewModel.allItems, photoRepository: photoRepository)
                     } label: {
                         Text("See All")
                             .font(.subheadline)
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showingAddSheet = true
+                    } label: {
+                        Image(systemName: "plus")
                     }
                 }
             }
@@ -57,6 +72,22 @@ struct UpcomingEventsDashboard: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .scheduledHangoutsDidChange)) { _ in
             Task { await viewModel.refresh() }
+        }
+        .sheet(isPresented: $showingAddSheet) {
+            AddEditEventSheet(
+                mode: .add(viewModel.contacts),
+                onSave: { contact, activity, interval in
+                    await viewModel.addEvent(contact: contact, activity: activity, interval: interval)
+                }
+            )
+        }
+        .sheet(item: $editingItem) { item in
+            AddEditEventSheet(
+                mode: .edit(item),
+                onSave: { _, activity, interval in
+                    await viewModel.editEvent(item.hangout, activity: activity, interval: interval)
+                }
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

**Issues:** #53

Currently, the only way to add a new event is by scheduling a suggested activity. Once an activity is scheduled, there is no way to change or cancel it. This PR extends the `UpcomingEventsDashboard` to include functionality for adding a new event, editing an existing one, or deleting an existing one.

## Notes

The user can add a new event using the `+` button on the trailing edge of the toolbar. On completion, and invitation is sent to the contact the event is scheduled with.

The user can edit or delete an event by pressing and holding on an existing event in the dashboard (this will bring up a `ContextMenu` with `Edit` or `Delete`). On deletion, the remote user is modified that the event was canceled. On edit, the previous event is deleted, and a new event is scheduled with the new information. The user can't change the contact the event is scheduled with -- to do that, they should delete the event and add a new event with the preferred contact.

A new method was added to `SuggestionService`: `proposeActivity(for:)` returns an activity suggestion for the given contact, using all context available except for a proposed time. This was needed because the existing method (`generateSuggestion()`) has fused logic that finds a proposed time, picks a contact, and generates a suggestion -- here, we just want the last step. This indicates that the `SuggestionService` interface may need some work in the future to make it more usable across different tasks.

**NOTE**: This code has been tested with the local remote notifications that emulate a remote user receiving the invitation. I haven't tested it with the full backend service.