### PR TITLE
Fix check-in button visibility and recipient for email-only contacts in weekly check-in

### DIFF
--- a/Eta/Views/WeeklyCheckIn/WeeklyCheckInView.swift
+++ b/Eta/Views/WeeklyCheckIn/WeeklyCheckInView.swift
@@ -46,7 +46,7 @@ struct WeeklyCheckInView: View {
             CheckInSheet(
                 displayName: homeViewModel.displayName(for: contact),
                 givenName: contact.givenName,
-                phoneNumber: contact.phoneNumber ?? "",
+                phoneNumber: contact.phoneNumber ?? contact.emailAddress ?? "",
                 initialTemplate: homeViewModel.checkInTemplate ?? "How have you been?",
                 onSend: { message, saveAsDefault in
                     if saveAsDefault { homeViewModel.updateCheckInTemplate(message) }
@@ -219,7 +219,7 @@ struct WeeklyCheckInView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 10))
             }
 
-            if contact.phoneNumber != nil {
+            if !(contact.phoneNumber ?? "").isEmpty || !(contact.emailAddress ?? "").isEmpty {
                 Button {
                     checkInSheetContact = contact
                 } label: {


### PR DESCRIPTION
- Weekly check-in was only showing the "Send check-in" button for contacts with a phone number, and only passing phone number to `CheckInSheet`
- Contacts with email only were silently excluded
- Now matches the Friends tab behavior: shows the button if either phone or email is present, and passes `phoneNumber ?? emailAddress` as the recipient
