### PR TITLE
Implement iMessage invite receiver flow

### DIFF
--- a/ETA-imessage-extension/Info.plist
+++ b/ETA-imessage-extension/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>SUPABASE_URL</key>
+	<string>rcsttehfkfghynyzmjca.supabase.co</string>
+	<key>SUPABASE_ANON_KEY</key>
+	<string>sb_publishable_zE5ABZ_fDaDIoGLHbtx1pg_OlZAQICR</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>

--- a/ETA-imessage-extension/MessagesViewController.swift
+++ b/ETA-imessage-extension/MessagesViewController.swift
@@ -285,7 +285,8 @@ class MessagesViewController: MSMessagesAppViewController {
         message.url = components.url
         message.layout = layout
 
-        conversation.insert(message) { [weak self] error in
+        // Use send() so the response goes out immediately without requiring a second tap.
+        conversation.send(message) { [weak self] error in
             if error == nil {
                 self?.requestPresentationStyle(.compact)
             }

--- a/ETA-imessage-extension/MessagesViewController.swift
+++ b/ETA-imessage-extension/MessagesViewController.swift
@@ -2,6 +2,71 @@ import UIKit
 import Messages
 import SwiftUI
 
+// MARK: - Supabase client (extension-side, minimal)
+//
+// Uses the same group.me.Eta App Group as the main app so both targets share one deviceID.
+// One-time Xcode setup required: add the "App Groups" capability (group.me.Eta) to BOTH targets
+// in Signing & Capabilities. Once done, the extension and main app share the same Supabase
+// deviceID, so InvitationManager.pollSentInvitations picks up extension-originated invites.
+
+private enum SharedDefaults {
+    static let appGroupID = "group.me.Eta"
+    static var suite: UserDefaults { UserDefaults(suiteName: appGroupID) ?? .standard }
+
+    static var deviceID: String {
+        if let saved = suite.string(forKey: "supabaseDeviceID") { return saved }
+        let id = UUID().uuidString
+        suite.set(id, forKey: "supabaseDeviceID")
+        return id
+    }
+}
+
+private struct ExtSupabase {
+    static var baseURL: String {
+        let host = (Bundle.main.object(forInfoDictionaryKey: "SUPABASE_URL") as? String) ?? ""
+        return host.isEmpty ? "" : "https://\(host)"
+    }
+    static var anonKey: String {
+        (Bundle.main.object(forInfoDictionaryKey: "SUPABASE_ANON_KEY") as? String) ?? ""
+    }
+    static var isConfigured: Bool { !baseURL.isEmpty && !anonKey.isEmpty }
+
+    static func rsvpURL(for invitationID: String) -> String? {
+        guard isConfigured else { return nil }
+        return "\(baseURL)/functions/v1/invite-rsvp?id=\(invitationID)"
+    }
+
+    static func updateStatus(id: String, to status: String) async {
+        guard isConfigured, let url = URL(string: "\(baseURL)/rest/v1/invitations?id=eq.\(id)") else { return }
+        var req = URLRequest(url: url)
+        req.httpMethod = "PATCH"
+        req.setValue("Bearer \(anonKey)", forHTTPHeaderField: "Authorization")
+        req.setValue(anonKey, forHTTPHeaderField: "apikey")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try? JSONSerialization.data(withJSONObject: ["status": status])
+        _ = try? await URLSession.shared.data(for: req)
+    }
+
+    static func postInvitation(id: String, activity: String, startTime: Date, endTime: Date) async {
+        guard isConfigured else { return }
+        let body: [String: Any] = [
+            "id": id, "from_device": SharedDefaults.deviceID,
+            "from_identifier": "", "to_identifier": "", "friend_name": "",
+            "activity": activity,
+            "start_time": ISO8601DateFormatter().string(from: startTime),
+            "end_time":   ISO8601DateFormatter().string(from: endTime),
+            "status": "pending"
+        ]
+        var req = URLRequest(url: URL(string: "\(baseURL)/rest/v1/invitations")!)
+        req.httpMethod = "POST"
+        req.setValue("Bearer \(anonKey)", forHTTPHeaderField: "Authorization")
+        req.setValue(anonKey, forHTTPHeaderField: "apikey")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        _ = try? await URLSession.shared.data(for: req)
+    }
+}
+
 // MARK: - Data
 
 private struct InviteActivity: Identifiable, Hashable {
@@ -52,7 +117,8 @@ class MessagesViewController: MSMessagesAppViewController {
         removeAllChildViewControllers()
 
         if let message = conversation.selectedMessage, let url = message.url {
-            presentInviteDetail(from: url, session: message.session, conversation: conversation)
+            let isSender = message.senderParticipantIdentifier == conversation.localParticipantIdentifier
+            presentInviteDetail(from: url, isSender: isSender, session: message.session, conversation: conversation)
             return
         }
 
@@ -89,30 +155,59 @@ class MessagesViewController: MSMessagesAppViewController {
         embed(UIHostingController(rootView: view))
     }
 
-    private func presentInviteDetail(from url: URL, session: MSSession?, conversation: MSConversation) {
+    private func presentInviteDetail(
+        from url: URL, isSender: Bool, session: MSSession?, conversation: MSConversation
+    ) {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let items = components.queryItems else { return }
 
-        let activityName = items.first { $0.name == "activity" }?.value ?? "Hang out"
-        let iconName = items.first { $0.name == "icon" }?.value ?? "calendar"
-        let timestamp = items.first { $0.name == "date" }?.value ?? ""
-        let note = items.first { $0.name == "note" }?.value ?? ""
-        let statusRaw = items.first { $0.name == "status" }?.value ?? "pending"
+        let activityName  = items.first { $0.name == "activity"     }?.value ?? "Hang out"
+        let iconName      = items.first { $0.name == "icon"         }?.value ?? "calendar"
+        let timestamp     = items.first { $0.name == "date"         }?.value ?? ""
+        let endTimestamp  = items.first { $0.name == "endTime"      }?.value ?? ""
+        let note          = items.first { $0.name == "note"         }?.value ?? ""
+        let statusRaw     = items.first { $0.name == "status"       }?.value ?? "pending"
+        let invitationID  = items.first { $0.name == "invitationID" }?.value ?? ""
         let status = InviteStatus(rawValue: statusRaw) ?? .pending
-        let date = Date(timeIntervalSince1970: Double(timestamp) ?? Date().timeIntervalSince1970)
+        let startDate = Date(timeIntervalSince1970: Double(timestamp) ?? Date().timeIntervalSince1970)
+        let endDate   = Date(timeIntervalSince1970: Double(endTimestamp) ?? startDate.addingTimeInterval(3600).timeIntervalSince1970)
         let color = InviteActivity.all.first { $0.name == activityName }?.color ?? etaTeal
+
+        // If the sender opens an already-accepted bubble, offer "Add to Eta".
+        let onAddToEta: (() -> Void)? = (isSender && status == .accepted) ? { [weak self] in
+            self?.openEtaApp(activity: activityName, startDate: startDate, endDate: endDate, invitationID: invitationID)
+        } : nil
 
         let view = EnvelopeDetailView(
             activityName: activityName, icon: iconName,
-            date: date, note: note, status: status, accentColor: color
+            date: startDate, note: note, status: status, accentColor: color,
+            isSender: isSender, onAddToEta: onAddToEta
         ) { [weak self] newStatus in
             self?.respondToInvite(
                 activityName: activityName, icon: iconName,
-                date: date, note: note, status: newStatus,
+                date: startDate, endDate: endDate, note: note,
+                invitationID: invitationID, status: newStatus,
                 session: session, conversation: conversation
             )
         }
         embed(UIHostingController(rootView: view))
+    }
+
+    private func openEtaApp(activity: String, startDate: Date, endDate: Date, invitationID: String = "") {
+        var c = URLComponents()
+        c.scheme = "eta"
+        c.host   = "invite-accepted"
+        var items: [URLQueryItem] = [
+            URLQueryItem(name: "activity", value: activity),
+            URLQueryItem(name: "start",    value: "\(startDate.timeIntervalSince1970)"),
+            URLQueryItem(name: "end",      value: "\(endDate.timeIntervalSince1970)"),
+        ]
+        if !invitationID.isEmpty {
+            items.append(URLQueryItem(name: "invitationID", value: invitationID))
+        }
+        c.queryItems = items
+        guard let url = c.url else { return }
+        extensionContext?.open(url, completionHandler: nil)
     }
 
     // MARK: - Sending
@@ -120,23 +215,35 @@ class MessagesViewController: MSMessagesAppViewController {
     private func sendInvite(activity: InviteActivity, date: Date, note: String) {
         guard let conversation = activeConversation else { return }
 
+        let invitationID = UUID().uuidString
+        let endTime = date.addingTimeInterval(3600)
+
+        Task { await ExtSupabase.postInvitation(id: invitationID, activity: activity.name, startTime: date, endTime: endTime) }
+
         let message = MSMessage(session: MSSession())
         let layout = MSMessageTemplateLayout()
         layout.image = renderEnvelopeCard(activity: activity, date: date, status: .pending)
         layout.caption = activity.name
         layout.subcaption = formatDate(date)
+        if let rsvpURL = ExtSupabase.rsvpURL(for: invitationID) {
+            layout.trailingSubcaption = "Tap to RSVP"
+            message.summaryText = "Hangout invite: \(activity.name)\nRSVP: \(rsvpURL)"
+        } else {
+            message.summaryText = "Hangout invite: \(activity.name)"
+        }
 
         var components = URLComponents()
         components.queryItems = [
-            URLQueryItem(name: "activity", value: activity.name),
-            URLQueryItem(name: "date", value: "\(date.timeIntervalSince1970)"),
-            URLQueryItem(name: "icon", value: activity.icon),
-            URLQueryItem(name: "note", value: note),
-            URLQueryItem(name: "status", value: InviteStatus.pending.rawValue),
+            URLQueryItem(name: "activity",     value: activity.name),
+            URLQueryItem(name: "date",         value: "\(date.timeIntervalSince1970)"),
+            URLQueryItem(name: "endTime",      value: "\(endTime.timeIntervalSince1970)"),
+            URLQueryItem(name: "icon",         value: activity.icon),
+            URLQueryItem(name: "note",         value: note),
+            URLQueryItem(name: "status",       value: InviteStatus.pending.rawValue),
+            URLQueryItem(name: "invitationID", value: invitationID),
         ]
         message.url = components.url
         message.layout = layout
-        message.summaryText = "Hangout invite: \(activity.name)"
 
         conversation.insert(message) { [weak self] error in
             if error == nil {
@@ -147,8 +254,8 @@ class MessagesViewController: MSMessagesAppViewController {
     }
 
     private func respondToInvite(
-        activityName: String, icon: String, date: Date,
-        note: String, status: InviteStatus,
+        activityName: String, icon: String, date: Date, endDate: Date,
+        note: String, invitationID: String, status: InviteStatus,
         session: MSSession?, conversation: MSConversation
     ) {
         let message = MSMessage(session: session ?? MSSession())
@@ -167,11 +274,13 @@ class MessagesViewController: MSMessagesAppViewController {
 
         var components = URLComponents()
         components.queryItems = [
-            URLQueryItem(name: "activity", value: activityName),
-            URLQueryItem(name: "date", value: "\(date.timeIntervalSince1970)"),
-            URLQueryItem(name: "icon", value: icon),
-            URLQueryItem(name: "note", value: note),
-            URLQueryItem(name: "status", value: status.rawValue),
+            URLQueryItem(name: "activity",     value: activityName),
+            URLQueryItem(name: "date",         value: "\(date.timeIntervalSince1970)"),
+            URLQueryItem(name: "endTime",      value: "\(endDate.timeIntervalSince1970)"),
+            URLQueryItem(name: "icon",         value: icon),
+            URLQueryItem(name: "note",         value: note),
+            URLQueryItem(name: "status",       value: status.rawValue),
+            URLQueryItem(name: "invitationID", value: invitationID),
         ]
         message.url = components.url
         message.layout = layout
@@ -180,6 +289,13 @@ class MessagesViewController: MSMessagesAppViewController {
             if error == nil {
                 self?.requestPresentationStyle(.compact)
             }
+        }
+
+        // When the receiver accepts, update Supabase so the sender's polling detects it,
+        // then open Eta to create a confirmed ScheduledHangout on the receiver's device.
+        if status == .accepted {
+            Task { await ExtSupabase.updateStatus(id: invitationID, to: "confirmed") }
+            openEtaApp(activity: activityName, startDate: date, endDate: endDate, invitationID: invitationID)
         }
     }
 
@@ -538,6 +654,8 @@ private struct EnvelopeDetailView: View {
     let note: String
     let status: InviteStatus
     let accentColor: Color
+    let isSender: Bool
+    let onAddToEta: (() -> Void)?
     let onRespond: (InviteStatus) -> Void
 
     @State private var flapOpened = false
@@ -602,8 +720,28 @@ private struct EnvelopeDetailView: View {
             }
 
             if status != .pending {
-                StatusBanner(status: status)
-                    .padding(.bottom, 20)
+                VStack(spacing: 12) {
+                    StatusBanner(status: status)
+                    if status == .accepted, let onAddToEta {
+                        Button(action: onAddToEta) {
+                            Label("Add to Eta", systemImage: "calendar.badge.plus")
+                                .font(.system(size: 15, weight: .semibold, design: .rounded))
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 14)
+                                .foregroundStyle(.white)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                        .fill(LinearGradient(
+                                            colors: [accentColor, accentColor.opacity(0.75)],
+                                            startPoint: .topLeading, endPoint: .bottomTrailing
+                                        ))
+                                )
+                        }
+                        .buttonStyle(ScaleButtonStyle())
+                        .padding(.horizontal, 20)
+                    }
+                }
+                .padding(.bottom, 20)
             }
         }
         .background(Color(.systemGroupedBackground))

--- a/ETA-imessage-extension/MessagesViewController.swift
+++ b/ETA-imessage-extension/MessagesViewController.swift
@@ -48,7 +48,10 @@ private struct ExtSupabase {
     }
 
     static func postInvitation(id: String, activity: String, startTime: Date, endTime: Date) async {
-        guard isConfigured else { return }
+        guard isConfigured else {
+            print("[ExtSupabase] not configured — baseURL='\(baseURL)' anonKey prefix='\(anonKey.prefix(10))'")
+            return
+        }
         let body: [String: Any] = [
             "id": id, "from_device": SharedDefaults.deviceID,
             "from_identifier": "", "to_identifier": "", "friend_name": "",
@@ -63,7 +66,12 @@ private struct ExtSupabase {
         req.setValue(anonKey, forHTTPHeaderField: "apikey")
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         req.httpBody = try? JSONSerialization.data(withJSONObject: body)
-        _ = try? await URLSession.shared.data(for: req)
+        if let (data, response) = try? await URLSession.shared.data(for: req) {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            print("[ExtSupabase] postInvitation status=\(status) body=\(String(data: data, encoding: .utf8) ?? "")")
+        } else {
+            print("[ExtSupabase] postInvitation network error")
+        }
     }
 }
 

--- a/Eta/Config.xcconfig
+++ b/Eta/Config.xcconfig
@@ -23,5 +23,5 @@ LLM_API_KEY =
 // Supabase project URL and anon key — get from supabase.com → Project Settings → API
 // DO NOT PUSH TO REMOTE
 SUPABASE_URL = rcsttehfkfghynyzmjca.supabase.co
-SUPABASE_ANON_KEY = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJjc3R0ZWhma2ZnaHlueXptamNhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzg2ODAxODUsImV4cCI6MjA5NDI1NjE4NX0.LEKcnc98AM3zlTTmzX-Z_EUbqJT5-m1Xjsz6HsbaH7U
+SUPABASE_ANON_KEY = sb_publishable_zE5ABZ_fDaDIoGLHbtx1pg_OlZAQICR
 

--- a/Eta/EtaApp.swift
+++ b/Eta/EtaApp.swift
@@ -250,41 +250,43 @@ struct EtaApp: App {
 
     var body: some Scene {
         WindowGroup {
-            if !hasPhoneSetup {
-                PhoneSetupView(phoneSetupService: phoneSetupService) {
-                    hasPhoneSetup = true
-                    if let id = phoneSetupService.myIdentifier {
-                        analyticsService.start(identifier: id)
-                        Task { await supabaseService.registerDevice(identifier: id) }
+            Group {
+                if !hasPhoneSetup {
+                    PhoneSetupView(phoneSetupService: phoneSetupService) {
+                        hasPhoneSetup = true
+                        if let id = phoneSetupService.myIdentifier {
+                            analyticsService.start(identifier: id)
+                            Task { await supabaseService.registerDevice(identifier: id) }
+                        }
                     }
+                } else if onboardingViewModel.hasCompletedOnboarding {
+                    MainTabView(
+                        homeViewModel: homeViewModel,
+                        connectionsViewModel: connectionsViewModel,
+                        suggestionViewModel: suggestionViewModel,
+                        upcomingEventsViewModel: upcomingEventsViewModel,
+                        settingsViewModel: settingsViewModel,
+                        availabilityViewModel: availabilityViewModel,
+                        analyticsService: analyticsService,
+                        invitationManager: invitationManager,
+                        photoRepository: photoRepository,
+                        reminderPhotoState: reminderPhotoState,
+                        nudgeService: nudgeService,
+                        nudgeScheduler: nudgeScheduler,
+                        weeklyCheckInService: weeklyCheckInService,
+                        weeklyCheckInState: weeklyCheckInState,
+                        nudgeReminderState: nudgeReminderState,
+                        receivedInviteState: receivedInviteState,
+                        chatViewModel: chatViewModel
+                    )
+                } else {
+                    OnboardingView(viewModel: onboardingViewModel, analyticsService: analyticsService)
                 }
-            } else if onboardingViewModel.hasCompletedOnboarding {
-                MainTabView(
-                    homeViewModel: homeViewModel,
-                    connectionsViewModel: connectionsViewModel,
-                    suggestionViewModel: suggestionViewModel,
-                    upcomingEventsViewModel: upcomingEventsViewModel,
-                    settingsViewModel: settingsViewModel,
-                    availabilityViewModel: availabilityViewModel,
-                    analyticsService: analyticsService,
-                    invitationManager: invitationManager,
-                    photoRepository: photoRepository,
-                    reminderPhotoState: reminderPhotoState,
-                    nudgeService: nudgeService,
-                    nudgeScheduler: nudgeScheduler,
-                    weeklyCheckInService: weeklyCheckInService,
-                    weeklyCheckInState: weeklyCheckInState,
-                    nudgeReminderState: nudgeReminderState,
-                    receivedInviteState: receivedInviteState,
-                    chatViewModel: chatViewModel
-                )
-            } else {
-                OnboardingView(viewModel: onboardingViewModel, analyticsService: analyticsService)
             }
-        }
-        .onOpenURL { url in
-            guard url.scheme == "eta" else { return }
-            invitationManager.handleInviteURL(url)
+            .onOpenURL { url in
+                guard url.scheme == "eta" else { return }
+                invitationManager.handleInviteURL(url)
+            }
         }
         .modelContainer(container)
     }

--- a/Eta/EtaApp.swift
+++ b/Eta/EtaApp.swift
@@ -282,6 +282,10 @@ struct EtaApp: App {
                 OnboardingView(viewModel: onboardingViewModel, analyticsService: analyticsService)
             }
         }
+        .onOpenURL { url in
+            guard url.scheme == "eta" else { return }
+            invitationManager.handleInviteURL(url)
+        }
         .modelContainer(container)
     }
 

--- a/Eta/Info.plist
+++ b/Eta/Info.plist
@@ -2,6 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>eta</string>
+			</array>
+		</dict>
+	</array>
 	<key>DEMO_CONTACTS</key>
 	<string>$(DEMO_CONTACTS)</string>
 	<key>LLM_API_KEY</key>

--- a/Eta/Models/ScheduledHangout.swift
+++ b/Eta/Models/ScheduledHangout.swift
@@ -13,8 +13,11 @@ final class ScheduledHangout {
     var id: UUID
     var invitationID: String?
     var contact: TrackedContact?
+    /// Display fallback when `contact` is nil — e.g. when accepted via iMessage or web RSVP
+    /// and the sender isn't in the receiver's TrackedContacts.
+    var contactName: String?
     var activity: String       // Activity.rawValue — stored as String; use resolvedActivity to get the enum
-    
+
     var startDate: Date
     var endDate: Date
 
@@ -30,6 +33,26 @@ final class ScheduledHangout {
     ) {
         self.id = id
         self.contact = contact
+        self.contactName = nil
+        self.activity = activity
+        self.startDate = selectedTime.start
+        self.endDate = selectedTime.end
+        self.scheduledAt = scheduledAt
+        self.inviteeResponse = .pending
+    }
+
+    /// Creates a confirmed hangout from an iMessage or web RSVP where the sender
+    /// may not be a TrackedContact on this device.
+    init(
+        id: UUID = UUID(),
+        contactName: String?,
+        activity: String,
+        selectedTime: DateInterval,
+        scheduledAt: Date = .now
+    ) {
+        self.id = id
+        self.contact = nil
+        self.contactName = contactName
         self.activity = activity
         self.startDate = selectedTime.start
         self.endDate = selectedTime.end

--- a/Eta/Services/InvitationManager.swift
+++ b/Eta/Services/InvitationManager.swift
@@ -96,14 +96,16 @@ final class InvitationManager {
         modelContext.insert(invitation)
         try modelContext.save()
 
-        if supabaseService.isConfigured,
-           let receiverDeviceID = await contactDeviceID(for: contact),
-           !receiverDeviceID.isEmpty {
+        if supabaseService.isConfigured {
+            // Post to Supabase regardless of whether the contact has the app registered.
+            // If they do, toIdentifier matches their device for push routing.
+            // If they don't, toIdentifier is empty and they accept via iMessage/web RSVP.
+            let receiverDeviceID = await contactDeviceID(for: contact)
             let remote = RemoteInvitation(
                 id: invitation.id,
                 fromDevice: supabaseService.deviceID,
                 fromIdentifier: phoneSetupService.myIdentifier ?? "",
-                toIdentifier: receiverDeviceID,
+                toIdentifier: receiverDeviceID ?? "",
                 friendName: friendName,
                 activity: activityName,
                 startTime: scheduledTime,
@@ -122,6 +124,7 @@ final class InvitationManager {
                 activityName: activityName
             )
         } else {
+            // Supabase not configured — dev/demo mode only. Simulate acceptance locally.
             try await notificationService.sendInvitation(for: invitation)
         }
 

--- a/Eta/Services/InvitationManager.swift
+++ b/Eta/Services/InvitationManager.swift
@@ -241,6 +241,56 @@ final class InvitationManager {
         try? await supabaseService.postCancellation(cancellation)
     }
 
+    // MARK: - Web RSVP / iMessage deep link
+
+    /// Handles `eta://invite-accepted?activity=<act>&start=<ts>&end=<ts>[&invitationID=<id>][&senderName=<name>]`.
+    ///
+    /// Sender path (invitationID matches a local Invitation): confirms it without creating a duplicate.
+    /// Receiver path: creates a new confirmed ScheduledHangout.
+    func handleInviteURL(_ url: URL) {
+        guard url.scheme == "eta", url.host == "invite-accepted",
+              let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
+        else { return }
+
+        let activity = items.first { $0.name == "activity" }?.value ?? ""
+        guard !activity.isEmpty else { return }
+
+        let startTs = Double(items.first { $0.name == "start" }?.value ?? "") ?? 0
+        let endTs   = Double(items.first { $0.name == "end"   }?.value ?? "") ?? 0
+        guard startTs > 0 else { return }
+
+        let startDate = Date(timeIntervalSince1970: startTs)
+        let endDate   = endTs > 0 ? Date(timeIntervalSince1970: endTs) : startDate.addingTimeInterval(3600)
+        let interval  = DateInterval(start: startDate, end: endDate)
+
+        if let invitationID = items.first(where: { $0.name == "invitationID" })?.value,
+           !invitationID.isEmpty {
+            let descriptor = FetchDescriptor<Invitation>(predicate: #Predicate { $0.id == invitationID })
+            if (try? modelContext.fetch(descriptor).first) != nil {
+                try? handleInvitationResponse(invitationID: invitationID, accepted: true)
+                return
+            }
+        }
+
+        let senderName = items.first { $0.name == "senderName" }?.value
+        let contact    = senderName.flatMap { findContact(byName: $0) }
+
+        let hangout: ScheduledHangout
+        if let contact {
+            hangout = ScheduledHangout(contact: contact, activity: activity, selectedTime: interval)
+        } else {
+            hangout = ScheduledHangout(
+                contactName: senderName ?? "via iMessage",
+                activity: activity,
+                selectedTime: interval
+            )
+        }
+        hangout.inviteeResponse = .confirmed
+        modelContext.insert(hangout)
+        try? modelContext.save()
+        NotificationCenter.default.post(name: .scheduledHangoutsDidChange, object: nil)
+    }
+
     // MARK: - Private
 
     private func expireStaleHangouts() {
@@ -277,22 +327,41 @@ final class InvitationManager {
         guard let updates = try? await supabaseService.fetchSentUpdates() else { return }
         for remote in updates {
             let descriptor = FetchDescriptor<Invitation>(predicate: #Predicate { $0.id == remote.id })
-            guard let inv = try? modelContext.fetch(descriptor).first,
-                  inv.status == .pending else { continue }
-            let accepted = remote.status == "confirmed"
-            try? handleInvitationResponse(invitationID: remote.id, accepted: accepted)
-            if accepted {
-                await notificationService.scheduleInviteAcceptedNotification(
-                    friendName: remote.friendName,
-                    activityName: remote.activity
-                )
-            } else {
-                await notificationService.scheduleInviteDeclinedNotification(
-                    friendName: remote.friendName,
-                    activityName: remote.activity
-                )
+            if let inv = try? modelContext.fetch(descriptor).first {
+                // App-originated invite: update existing Invitation and its ScheduledHangout.
+                guard inv.status == .pending else { continue }
+                let accepted = remote.status == "confirmed"
+                try? handleInvitationResponse(invitationID: remote.id, accepted: accepted)
+                if accepted {
+                    await notificationService.scheduleInviteAcceptedNotification(
+                        friendName: remote.friendName,
+                        activityName: remote.activity
+                    )
+                } else {
+                    await notificationService.scheduleInviteDeclinedNotification(
+                        friendName: remote.friendName,
+                        activityName: remote.activity
+                    )
+                }
+                await supabaseService.deleteInvitation(id: remote.id)
+            } else if remote.status == "confirmed" {
+                // Extension-originated invite: no local Invitation exists.
+                // Create a confirmed ScheduledHangout so the sender sees the accepted event.
+                let name = remote.friendName.isEmpty ? nil : remote.friendName
+                let contact = name.flatMap { findContact(byName: $0) }
+                let interval = DateInterval(start: remote.startTime, end: remote.endTime)
+                let hangout: ScheduledHangout
+                if let contact {
+                    hangout = ScheduledHangout(contact: contact, activity: remote.activity, selectedTime: interval)
+                } else {
+                    hangout = ScheduledHangout(contactName: name ?? "via iMessage", activity: remote.activity, selectedTime: interval)
+                }
+                hangout.inviteeResponse = .confirmed
+                modelContext.insert(hangout)
+                try? modelContext.save()
+                NotificationCenter.default.post(name: .scheduledHangoutsDidChange, object: nil)
+                await supabaseService.deleteInvitation(id: remote.id)
             }
-            await supabaseService.deleteInvitation(id: remote.id)
         }
         await supabaseService.deleteExpiredSentInvitations()
     }
@@ -380,6 +449,16 @@ final class InvitationManager {
             if let email = contact.emailAddress?.lowercased(),
                email == identifier { return true }
             return false
+        }
+    }
+
+    private func findContact(byName name: String) -> TrackedContact? {
+        let all = (try? modelContext.fetch(FetchDescriptor<TrackedContact>())) ?? []
+        let lower = name.lowercased()
+        return all.first {
+            $0.name.lowercased().contains(lower)
+            || $0.givenName.lowercased() == lower
+            || "\($0.givenName) \($0.familyName)".lowercased() == lower
         }
     }
 }

--- a/Eta/Services/SupabaseService.swift
+++ b/Eta/Services/SupabaseService.swift
@@ -144,10 +144,17 @@ final class SupabaseService {
         self.baseURL = host.isEmpty ? "" : "https://\(host)"
         self.anonKey = (Bundle.main.object(forInfoDictionaryKey: "SUPABASE_ANON_KEY") as? String) ?? ""
 
-        if let saved = UserDefaults.standard.string(forKey: "supabaseDeviceID") {
+        // Use the App Group suite so the device ID matches what the iMessage extension writes.
+        // App Groups must be enabled on both targets (group.me.Eta) in Signing & Capabilities.
+        let sharedDefaults = UserDefaults(suiteName: "group.me.Eta") ?? .standard
+        if let saved = sharedDefaults.string(forKey: "supabaseDeviceID") {
             self.deviceID = saved
+        } else if let migrated = UserDefaults.standard.string(forKey: "supabaseDeviceID") {
+            sharedDefaults.set(migrated, forKey: "supabaseDeviceID")
+            self.deviceID = migrated
         } else {
             let id = UUID().uuidString
+            sharedDefaults.set(id, forKey: "supabaseDeviceID")
             UserDefaults.standard.set(id, forKey: "supabaseDeviceID")
             self.deviceID = id
         }

--- a/EtaTests/InviteReceivingTests.swift
+++ b/EtaTests/InviteReceivingTests.swift
@@ -1,0 +1,151 @@
+import Testing
+import SwiftData
+import Foundation
+@testable import Eta
+
+// MARK: - Mock notification service
+
+@MainActor
+private final class MockNotificationService: NotificationServiceProtocol {
+    func requestAuthorization() async throws {}
+    func sendInvitation(for invitation: Invitation) async throws {}
+    func cancelNotification(for invitationID: String) {}
+    func scheduleFeedbackNotification(hangoutID: UUID, friendName: String, activityName: String, at date: Date) async throws {}
+    func scheduleHangoutReminders(hangoutID: UUID, activityName: String, friendName: String, startDate: Date, endDate: Date) async {}
+    func cancelHangoutReminders(for hangoutID: UUID) {}
+    func scheduleReceivedInvitationNotification(remote: RemoteInvitation) async throws {}
+    func scheduleInviteSentNotification(friendName: String, activityName: String) async {}
+    func scheduleInviteDeclinedNotification(friendName: String, activityName: String) async {}
+}
+
+// MARK: - Tests
+
+/// Tests for the iMessage invite receiving flow (handleInviteURL).
+///
+/// SupabaseService.isConfigured is false in the test bundle (no Info.plist keys),
+/// so all Supabase code paths are no-ops and no network calls are made.
+@MainActor
+struct InviteReceivingTests {
+
+    let manager: InvitationManager
+    let ctx: ModelContext
+    // Held strongly so SwiftData doesn't tear down mid-test.
+    private let container: ModelContainer
+
+    init() throws {
+        container = try ModelContainer(
+            for: TrackedContact.self, ScheduledHangout.self,
+                Invitation.self, PendingReceivedInvitation.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        ctx = container.mainContext
+        manager = InvitationManager(
+            notificationService: MockNotificationService(),
+            modelContext: ctx,
+            supabaseService: SupabaseService(),
+            phoneSetupService: PhoneSetupService(),
+            pendingReceivedRepo: PendingReceivedInvitationRepository(modelContext: ctx)
+        )
+    }
+
+    // MARK: - Receiver path
+
+    @Test("Receiver: creates a confirmed ScheduledHangout with 'via iMessage' fallback name")
+    func receiverPath_createsHangout() throws {
+        let url = URL(string: "eta://invite-accepted?activity=Walk&start=1755000000&end=1755003600")!
+        manager.handleInviteURL(url)
+
+        let hangouts = try ctx.fetch(FetchDescriptor<ScheduledHangout>())
+        #expect(hangouts.count == 1)
+        #expect(hangouts[0].activity == "Walk")
+        #expect(hangouts[0].inviteeResponse == .confirmed)
+        #expect(hangouts[0].contact == nil)
+        #expect(hangouts[0].contactName == "via iMessage")
+    }
+
+    @Test("Receiver: senderName param links to an existing TrackedContact")
+    func receiverPath_senderName_linksContact() throws {
+        let contact = TrackedContact(cnContactIdentifier: "c1", name: "Alice Smith",
+            givenName: "Alice", familyName: "Smith")
+        ctx.insert(contact)
+
+        let url = URL(string: "eta://invite-accepted?activity=Coffee&start=1755000000&end=1755003600&senderName=Alice%20Smith")!
+        manager.handleInviteURL(url)
+
+        let hangouts = try ctx.fetch(FetchDescriptor<ScheduledHangout>())
+        #expect(hangouts.count == 1)
+        #expect(hangouts[0].contact?.name == "Alice Smith")
+    }
+
+    @Test("Receiver: missing activity param → no hangout created")
+    func receiverPath_missingActivity_noHangout() throws {
+        let url = URL(string: "eta://invite-accepted?start=1755000000&end=1755003600")!
+        manager.handleInviteURL(url)
+
+        let hangouts = try ctx.fetch(FetchDescriptor<ScheduledHangout>())
+        #expect(hangouts.isEmpty)
+    }
+
+    @Test("Receiver: missing start timestamp → no hangout created")
+    func receiverPath_missingStart_noHangout() throws {
+        let url = URL(string: "eta://invite-accepted?activity=Walk")!
+        manager.handleInviteURL(url)
+
+        let hangouts = try ctx.fetch(FetchDescriptor<ScheduledHangout>())
+        #expect(hangouts.isEmpty)
+    }
+
+    @Test("Receiver: missing end timestamp → endDate defaults to start + 1 hour")
+    func receiverPath_missingEnd_defaultsDuration() throws {
+        let url = URL(string: "eta://invite-accepted?activity=Walk&start=1755000000")!
+        manager.handleInviteURL(url)
+
+        let hangouts = try ctx.fetch(FetchDescriptor<ScheduledHangout>())
+        #expect(hangouts.count == 1)
+        let expectedEnd = Date(timeIntervalSince1970: 1755000000 + 3600)
+        #expect(hangouts[0].endDate == expectedEnd)
+    }
+
+    // MARK: - Sender path (invitationID present)
+
+    @Test("Sender: invitationID matches local Invitation → confirms it without creating a duplicate")
+    func senderPath_confirmsExisting_noDuplicate() throws {
+        let contact = TrackedContact(cnContactIdentifier: "c1", name: "Bob Jones",
+            givenName: "Bob", familyName: "Jones")
+        ctx.insert(contact)
+
+        let hangoutID = UUID()
+        let interval = DateInterval(
+            start: Date(timeIntervalSince1970: 1755000000),
+            end:   Date(timeIntervalSince1970: 1755003600)
+        )
+        let hangout = ScheduledHangout(id: hangoutID, contact: contact, activity: "Walk", selectedTime: interval)
+        ctx.insert(hangout)
+
+        let invID = UUID().uuidString
+        let inv = Invitation(id: invID, activityName: "Walk", friendName: "Bob Jones",
+            scheduledTime: Date(timeIntervalSince1970: 1755000000), hangoutID: hangoutID)
+        ctx.insert(inv)
+        try ctx.save()
+
+        let url = URL(string: "eta://invite-accepted?activity=Walk&start=1755000000&end=1755003600&invitationID=\(invID)")!
+        manager.handleInviteURL(url)
+
+        let hangouts = try ctx.fetch(FetchDescriptor<ScheduledHangout>())
+        #expect(hangouts.count == 1, "Should not create a duplicate ScheduledHangout")
+        #expect(hangouts[0].inviteeResponse == .confirmed)
+
+        let invitations = try ctx.fetch(FetchDescriptor<Invitation>())
+        #expect(invitations[0].status == .confirmed)
+    }
+
+    @Test("Sender: invitationID present but unrecognised → falls through to receiver path")
+    func senderPath_unknownID_takesReceiverPath() throws {
+        let url = URL(string: "eta://invite-accepted?activity=Walk&start=1755000000&end=1755003600&invitationID=no-such-id")!
+        manager.handleInviteURL(url)
+
+        let hangouts = try ctx.fetch(FetchDescriptor<ScheduledHangout>())
+        #expect(hangouts.count == 1)
+        #expect(hangouts[0].inviteeResponse == .confirmed)
+    }
+}


### PR DESCRIPTION
## Summary

- When a recipient taps **"I'm in!"** in the iMessage extension, the extension now calls `ExtSupabase.updateStatus` to mark the Supabase row as `confirmed`, so the sender's `pollSentInvitations` detects the acceptance within 10 seconds
- `SupabaseService` migrates `deviceID` to the App Group shared `UserDefaults` suite (`group.me.Eta`) so the main app and extension share the same device identity — without this, `fetchSentUpdates` queried by the wrong `from_device` and never found extension-originated invites
- `pollSentInvitations` now creates a confirmed `ScheduledHangout` for extension-originated invites (which have no local `Invitation` record) when the receiver accepts
- `handleInviteURL` added to `InvitationManager`; detects the sender path when `invitationID` matches a local `Invitation` and confirms it in place rather than inserting a duplicate `ScheduledHangout`
- `invitationID` now carried through the `eta://invite-accepted` deep link in both the receiver accept path and the sender's "Add to Eta" button
- `ScheduledHangout` gains a `contactName` field and corresponding initializer for hangouts created without a matching `TrackedContact` (iMessage or web RSVP path)
- `onOpenURL` handler in `EtaApp` routes `eta://invite-accepted` deep links to `InvitationManager`