### PR TITLE
Implement 6.2 Adjust and 6.3 Friends nudge features

### DIFF
--- a/ETA-imessage-extension/Info.plist
+++ b/ETA-imessage-extension/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>SUPABASE_URL</key>
+	<string>rcsttehfkfghynyzmjca.supabase.co</string>
+	<key>SUPABASE_ANON_KEY</key>
+	<string>sb_publishable_zE5ABZ_fDaDIoGLHbtx1pg_OlZAQICR</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>

--- a/Eta/App/MainTabView.swift
+++ b/Eta/App/MainTabView.swift
@@ -42,7 +42,10 @@ struct MainTabView: View {
                     settingsViewModel: settingsViewModel,
                     analyticsService: analyticsService,
                     weeklyCheckInState: weeklyCheckInState,
-                    onShowSettings: { showingSettings = true }
+                    onShowSettings: { showingSettings = true },
+                    onNudge: { contact in
+                        Task { await invitationManager.sendFriendNudge(to: contact) }
+                    }
                 )
                 .walkthrough(key: "friends", steps: TabWalkthroughs.friends)
             }
@@ -106,18 +109,25 @@ struct MainTabView: View {
                     photoRepository: photoRepository,
                     nudgeScheduler: nudgeScheduler,
                     onScheduleNow: { suggestion in
+                        nudgeService.recordEngagement()
                         analyticsService.logNudgeAction("scheduleNow", friendName: nudgeReminderState.friendName, activity: activityRawValue)
                         nudgeReminderState.clear()
                         selectedTab = .suggestions
                         suggestionViewModel.scheduleFromNudge(suggestion)
                     },
                     onSuggestions: {
+                        nudgeService.recordEngagement()
                         analyticsService.logNudgeAction("viewSuggestions", friendName: nudgeReminderState.friendName, activity: activityRawValue)
                         nudgeReminderState.clear()
                         selectedTab = .suggestions
                     },
                     onDismiss: {
+                        nudgeService.recordDismissal()
                         analyticsService.logNudgeAction("maybeLater", friendName: nudgeReminderState.friendName, activity: activityRawValue)
+                        nudgeReminderState.clear()
+                    },
+                    onReduceFrequency: {
+                        nudgeService.reduceFrequency()
                         nudgeReminderState.clear()
                     }
                 )

--- a/Eta/Config.xcconfig
+++ b/Eta/Config.xcconfig
@@ -23,5 +23,5 @@ LLM_API_KEY =
 // Supabase project URL and anon key — get from supabase.com → Project Settings → API
 // DO NOT PUSH TO REMOTE
 SUPABASE_URL = rcsttehfkfghynyzmjca.supabase.co
-SUPABASE_ANON_KEY = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJjc3R0ZWhma2ZnaHlueXptamNhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzg2ODAxODUsImV4cCI6MjA5NDI1NjE4NX0.LEKcnc98AM3zlTTmzX-Z_EUbqJT5-m1Xjsz6HsbaH7U
+SUPABASE_ANON_KEY = sb_publishable_zE5ABZ_fDaDIoGLHbtx1pg_OlZAQICR
 

--- a/Eta/EtaApp.swift
+++ b/Eta/EtaApp.swift
@@ -93,7 +93,8 @@ struct EtaApp: App {
         let nudgeService = NudgeService(
             relationshipService: relationshipService,
             photoRepository: photoRepository,
-            runner: GitHubModelsLLMRunner()
+            runner: GitHubModelsLLMRunner(),
+            preferencesService: preferencesService
         )
         self.nudgeService = nudgeService
         self.weeklyCheckInService = WeeklyCheckInService(preferencesService: preferencesService)

--- a/Eta/Info.plist
+++ b/Eta/Info.plist
@@ -2,6 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>eta</string>
+			</array>
+		</dict>
+	</array>
 	<key>DEMO_CONTACTS</key>
 	<string>$(DEMO_CONTACTS)</string>
 	<key>LLM_API_KEY</key>

--- a/Eta/Models/UserPreferences.swift
+++ b/Eta/Models/UserPreferences.swift
@@ -17,6 +17,8 @@ struct UserPreferences: Codable {
     var weeklyCheckInDay: Int
     /// Time of day for the weekly check-in notification. Only hour/minute components are used.
     var weeklyCheckInTime: Date
+    /// How many days between nudge notifications. 1 = daily, 7 = weekly.
+    var nudgeFrequencyDays: Int
 
     init(
         preferredActivities: [String] = Activity.allCases.map { $0.rawValue },
@@ -41,7 +43,8 @@ struct UserPreferences: Codable {
             components.hour = 18
             components.minute = 0
             return Calendar.current.date(from: components) ?? Date()
-        }()
+        }(),
+        nudgeFrequencyDays: Int = 1
     ) {
         self.preferredActivities = preferredActivities
         self.relationshipHealthThreshold = relationshipHealthThreshold
@@ -56,6 +59,7 @@ struct UserPreferences: Codable {
         self.weeklyCheckInEnabled = weeklyCheckInEnabled
         self.weeklyCheckInDay = weeklyCheckInDay
         self.weeklyCheckInTime = weeklyCheckInTime
+        self.nudgeFrequencyDays = nudgeFrequencyDays
     }
 
     func encode(to encoder: Encoder) throws {
@@ -73,6 +77,7 @@ struct UserPreferences: Codable {
         try container.encode(weeklyCheckInEnabled, forKey: .weeklyCheckInEnabled)
         try container.encode(weeklyCheckInDay, forKey: .weeklyCheckInDay)
         try container.encode(weeklyCheckInTime.timeIntervalSince1970, forKey: .weeklyCheckInTimeInterval)
+        try container.encode(nudgeFrequencyDays, forKey: .nudgeFrequencyDays)
     }
 
     init(from decoder: Decoder) throws {
@@ -90,6 +95,7 @@ struct UserPreferences: Codable {
         userLongitude = try container.decodeIfPresent(Double.self, forKey: .userLongitude)
         weeklyCheckInEnabled = try container.decodeIfPresent(Bool.self, forKey: .weeklyCheckInEnabled) ?? true
         weeklyCheckInDay = try container.decodeIfPresent(Int.self, forKey: .weeklyCheckInDay) ?? 1
+        nudgeFrequencyDays = try container.decodeIfPresent(Int.self, forKey: .nudgeFrequencyDays) ?? 1
         let checkInTimeInterval = try container.decodeIfPresent(TimeInterval.self, forKey: .weeklyCheckInTimeInterval)
         if let t = checkInTimeInterval {
             weeklyCheckInTime = Date(timeIntervalSince1970: t)
@@ -113,5 +119,6 @@ struct UserPreferences: Codable {
         case weeklyCheckInEnabled
         case weeklyCheckInDay
         case weeklyCheckInTimeInterval
+        case nudgeFrequencyDays
     }
 }

--- a/Eta/Services/InvitationManager.swift
+++ b/Eta/Services/InvitationManager.swift
@@ -217,6 +217,16 @@ final class InvitationManager {
         NotificationCenter.default.post(name: .scheduledHangoutsDidChange, object: nil)
     }
 
+    /// Sends a nudge to a friend who has the app installed.
+    func sendFriendNudge(to contact: TrackedContact) async {
+        let identifier: String
+        if let phone = contact.phoneNumber { identifier = PhoneSetupService.normalized(phone) }
+        else if let email = contact.emailAddress?.lowercased() { identifier = email }
+        else { return }
+        let fromName = phoneSetupService.myIdentifier ?? "A friend"
+        await supabaseService.sendFriendNudge(to: identifier, fromName: fromName)
+    }
+
     // MARK: - Polling
 
     /// Called on every app foreground. Checks for new received invites and sent invite responses.
@@ -224,8 +234,18 @@ final class InvitationManager {
         async let sent: () = pollSentInvitations()
         async let received: () = pollReceivedInvitations()
         async let cancellations: () = pollCancellations()
-        _ = await (sent, received, cancellations)
+        async let nudges: () = pollFriendNudges()
+        _ = await (sent, received, cancellations, nudges)
         expireStaleHangouts()
+    }
+
+    private func pollFriendNudges() async {
+        guard supabaseService.isConfigured,
+              let myIdentifier = phoneSetupService.myIdentifier else { return }
+        let senderNames = await supabaseService.fetchAndDeleteReceivedNudges(myIdentifier: myIdentifier)
+        for name in senderNames {
+            await notificationService.scheduleFriendNudgeNotification(fromName: name)
+        }
     }
 
     func cancelEventByValues(contact: TrackedContact, invitationID: String, activity: String) async {

--- a/Eta/Services/LocalNotificationService.swift
+++ b/Eta/Services/LocalNotificationService.swift
@@ -196,6 +196,22 @@ final class LocalNotificationService: NotificationServiceProtocol {
         try? await center.add(request)
     }
 
+    func scheduleFriendNudgeNotification(fromName: String) async {
+        guard preferencesService.preferences.enableNotifications else { return }
+        let content = UNMutableNotificationContent()
+        content.title = "\(fromName) wants to hang out!"
+        content.body = "They're thinking of you — why not reach out?"
+        content.sound = .default
+        content.userInfo = ["notificationType": "friendNudge", "fromName": fromName]
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: "friend-nudge-\(UUID().uuidString)",
+            content: content,
+            trigger: trigger
+        )
+        try? await center.add(request)
+    }
+
     private func formattedTime(_ date: Date) -> String {
         let formatter = DateFormatter()
         formatter.timeStyle = .short

--- a/Eta/Services/NotificationServiceProtocol.swift
+++ b/Eta/Services/NotificationServiceProtocol.swift
@@ -34,4 +34,7 @@ protocol NotificationServiceProtocol {
 
     /// Schedule a notification for the receiver when the sender cancels a confirmed event.
     func scheduleEventCanceledNotification(friendName: String, activityName: String) async
+
+    /// Schedule a notification when a friend sends a nudge via the friend-nudge feature.
+    func scheduleFriendNudgeNotification(fromName: String) async
 }

--- a/Eta/Services/NudgeService.swift
+++ b/Eta/Services/NudgeService.swift
@@ -21,11 +21,15 @@ extension Notification.Name {
 /// without — so the no-key fallback in GitHubModelsLLMRunner is the single source of random enum.
 /// hasPhotos / Banner photo both branch on llmMode (not force): llmMode → any friend; else → enum lookup.
 final class NudgeService {
-    private static let scheduledNudgeID = "me.Eta.nudge.scheduled"
+    private static let scheduledNudgeID  = "me.Eta.nudge.scheduled"
+    private static let lastNudgeDateKey  = "me.Eta.nudge.lastSentDate"
+    private static let dismissalCountKey = "me.Eta.nudge.consecutiveDismissals"
+    private static let lastContactIDKey  = "me.Eta.nudge.lastContactID"
 
     private let relationshipService: RelationshipService
     private let photoRepository: ActivityPhotoRepository
     private let runner: any LLMRunner
+    private let preferencesService: PreferencesService
 
     private var llmMode: Bool {
         (Bundle.main.object(forInfoDictionaryKey: "LLM_API_KEY") as? String).map { !$0.isEmpty } ?? false
@@ -34,10 +38,12 @@ final class NudgeService {
     init(
         relationshipService: RelationshipService,
         photoRepository: ActivityPhotoRepository,
-        runner: any LLMRunner
+        runner: any LLMRunner,
+        preferencesService: PreferencesService
     ) {
         self.relationshipService = relationshipService
         self.photoRepository = photoRepository
+        self.preferencesService = preferencesService
         self.runner = runner
 
         NotificationCenter.default.addObserver(
@@ -58,17 +64,48 @@ final class NudgeService {
         if !force {
             UNUserNotificationCenter.current()
                 .removePendingNotificationRequests(withIdentifiers: [Self.scheduledNudgeID])
+            UserDefaults.standard.set(Date(), forKey: Self.lastNudgeDateKey)
         }
 
         let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
         try? await UNUserNotificationCenter.current().add(request)
     }
 
+    /// Call when the user taps "Maybe later". After 3 consecutive dismissals the interval
+    /// is automatically bumped by one day (phase-out).
+    func recordDismissal() {
+        let count = UserDefaults.standard.integer(forKey: Self.dismissalCountKey) + 1
+        if count >= 3 {
+            bumpFrequency()
+            UserDefaults.standard.set(0, forKey: Self.dismissalCountKey)
+        } else {
+            UserDefaults.standard.set(count, forKey: Self.dismissalCountKey)
+        }
+    }
+
+    /// Call when the user acts on a nudge. Resets the dismissal counter.
+    func recordEngagement() {
+        UserDefaults.standard.set(0, forKey: Self.dismissalCountKey)
+    }
+
+    /// Immediately increase the nudge interval by one day (cap: 7).
+    func reduceFrequency() {
+        bumpFrequency()
+    }
+
     // MARK: - Private
 
     private func buildNudge(force: Bool) async -> (UNMutableNotificationContent?, String, UNNotificationTrigger?) {
         let healthScores = await relationshipService.computeHealth()
-        let best = healthScores.max(by: { $0.score < $1.score })
+        // Rotation: skip the last-nudged contact when other overdue options exist.
+        let lastID = UserDefaults.standard.string(forKey: Self.lastContactIDKey)
+            .flatMap { UUID(uuidString: $0) }
+        let candidates = healthScores.filter { $0.score > 0 }
+        let pool = candidates.count > 1 ? candidates.filter { $0.contact.id != lastID } : candidates
+        let best = (pool.isEmpty ? candidates : pool).max(by: { $0.score < $1.score })
+        if let id = best?.contact.id {
+            UserDefaults.standard.set(id.uuidString, forKey: Self.lastContactIDKey)
+        }
 
         var activityDescription: String
         var fallbackActivity: Activity
@@ -169,7 +206,7 @@ final class NudgeService {
         let identifier = force ? "nudge-debug-\(UUID().uuidString)" : Self.scheduledNudgeID
         let trigger: UNNotificationTrigger = force
             ? UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
-            : UNCalendarNotificationTrigger(dateMatching: next9am(), repeats: false)
+            : UNCalendarNotificationTrigger(dateMatching: nextFireDate(), repeats: false)
 
         return (content, identifier, trigger)
     }
@@ -198,15 +235,28 @@ final class NudgeService {
         return trimmed.isEmpty ? (Activity.allCases.randomElement()?.rawValue ?? Activity.walk.rawValue) : trimmed
     }
 
-    private func next9am() -> DateComponents {
-        var components = Calendar.current.dateComponents([.year, .month, .day], from: .now)
-        components.hour = 9
-        components.minute = 0
-        let today9am = Calendar.current.date(from: components)!
-        let fireDate = today9am > .now
-            ? today9am
-            : Calendar.current.date(byAdding: .day, value: 1, to: today9am)!
-        return Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: fireDate)
+    private func nextFireDate() -> DateComponents {
+        let frequencyDays = preferencesService.preferences.nudgeFrequencyDays
+        let lastDate = UserDefaults.standard.object(forKey: Self.lastNudgeDateKey) as? Date
+        let baseDay = lastDate.flatMap {
+            Calendar.current.date(byAdding: .day, value: frequencyDays, to: $0)
+        } ?? Date()
+        let preferredTime = preferencesService.preferences.notificationTime
+        let timeComps = Calendar.current.dateComponents([.hour, .minute], from: preferredTime)
+        var comps = Calendar.current.dateComponents([.year, .month, .day], from: baseDay)
+        comps.hour = timeComps.hour ?? 9
+        comps.minute = timeComps.minute ?? 0
+        let fireAt = Calendar.current.date(from: comps) ?? Date()
+        let adjusted = fireAt > Date()
+            ? fireAt
+            : Calendar.current.date(byAdding: .day, value: 1, to: fireAt)!
+        return Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: adjusted)
+    }
+
+    private func bumpFrequency() {
+        let current = preferencesService.preferences.nudgeFrequencyDays
+        guard current < 7 else { return }
+        preferencesService.updateNudgeFrequency(current + 1)
     }
 
     private func makeAttachment(from data: Data?) -> UNNotificationAttachment? {

--- a/Eta/Services/PreferencesService.swift
+++ b/Eta/Services/PreferencesService.swift
@@ -38,6 +38,11 @@ final class PreferencesService {
         savePreferences()
     }
 
+    func updateNudgeFrequency(_ days: Int) {
+        preferences.nudgeFrequencyDays = min(max(days, 1), 7)
+        savePreferences()
+    }
+
     func updateUserCoordinates(_ latitude: Double, _ longitude: Double) {
         preferences.userLatitude = latitude
         preferences.userLongitude = longitude

--- a/Eta/Services/SupabaseService.swift
+++ b/Eta/Services/SupabaseService.swift
@@ -247,6 +247,47 @@ final class SupabaseService {
         try? await request(path: path, method: "DELETE")
     }
 
+    // MARK: - Friend nudges
+    //
+    // Requires a friend_nudges table in Supabase:
+    //
+    // CREATE TABLE friend_nudges (
+    //   id            TEXT PRIMARY KEY,
+    //   from_device   TEXT NOT NULL,
+    //   from_name     TEXT NOT NULL,
+    //   to_identifier TEXT NOT NULL,
+    //   created_at    TIMESTAMPTZ DEFAULT now()
+    // );
+    // ALTER TABLE friend_nudges ENABLE ROW LEVEL SECURITY;
+    // CREATE POLICY "allow all" ON friend_nudges FOR ALL USING (true) WITH CHECK (true);
+
+    func sendFriendNudge(to toIdentifier: String, fromName: String) async {
+        guard isConfigured else { return }
+        let body: [String: Any] = [
+            "id": UUID().uuidString,
+            "from_device": deviceID,
+            "from_name": fromName,
+            "to_identifier": toIdentifier
+        ]
+        try? await request(path: "/rest/v1/friend_nudges", method: "POST", body: body)
+    }
+
+    func fetchAndDeleteReceivedNudges(myIdentifier: String) async -> [String] {
+        guard isConfigured else { return [] }
+        let encoded = urlEncoded(myIdentifier)
+        guard let data = try? await request(
+            path: "/rest/v1/friend_nudges?to_identifier=eq.\(encoded)&select=id,from_name",
+            method: "GET"
+        ),
+        let rows = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return [] }
+        let names = rows.compactMap { $0["from_name"] as? String }
+        for id in rows.compactMap({ $0["id"] as? String }) {
+            try? await request(path: "/rest/v1/friend_nudges?id=eq.\(id)", method: "DELETE")
+        }
+        return names
+    }
+
     // MARK: - Analytics
 
     func postAnalyticsEvent(

--- a/Eta/Views/Connections/ConnectionsView.swift
+++ b/Eta/Views/Connections/ConnectionsView.swift
@@ -7,6 +7,7 @@ struct ConnectionsView: View {
     let analyticsService: AnalyticsService
     let weeklyCheckInState: WeeklyCheckInState
     let onShowSettings: () -> Void
+    var onNudge: ((TrackedContact) -> Void)?
 
     @State private var searchText = ""
     @State private var showingAddSheet = false
@@ -65,7 +66,8 @@ struct ConnectionsView: View {
                             health: item.health,
                             displayName: homeViewModel.displayName(for: item.contact),
                             homeViewModel: homeViewModel,
-                            analyticsService: analyticsService
+                            analyticsService: analyticsService,
+                            onNudge: onNudge.map { fn in { fn(item.contact) } }
                         )
                     } label: {
                         FriendSpotlightCard(
@@ -162,7 +164,8 @@ struct ConnectionsView: View {
                             ),
                             displayName: viewModel.displayName(for: contact),
                             homeViewModel: homeViewModel,
-                            analyticsService: analyticsService
+                            analyticsService: analyticsService,
+                            onNudge: onNudge.map { fn in { fn(contact) } }
                         )
                     } label: {
                         ContactRow(contact: contact, viewModel: viewModel, activeFilter: viewModel.selectedTagFilter)

--- a/Eta/Views/Friends/FriendDetailView.swift
+++ b/Eta/Views/Friends/FriendDetailView.swift
@@ -7,6 +7,7 @@ struct FriendDetailView: View {
     let homeViewModel: HomeViewModel
     var analyticsService: AnalyticsService?
     var onAddGoal: (() -> Void)?
+    var onNudge: (() -> Void)?
 
     @Environment(\.openURL) private var openURL
     @State private var showingGoalCreation = false
@@ -573,6 +574,13 @@ struct FriendDetailView: View {
                 } label: {
                     Label("Log a hangout", systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90")
                         .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+
+            if let onNudge, hasPhone {
+                Button(action: onNudge) {
+                    Label("Nudge them", systemImage: "hand.wave").frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.bordered)
             }

--- a/Eta/Views/Reminders/NudgeReminderSheet.swift
+++ b/Eta/Views/Reminders/NudgeReminderSheet.swift
@@ -9,6 +9,7 @@ struct NudgeReminderSheet: View {
     let onScheduleNow: (Suggestion) -> Void
     let onSuggestions: () -> Void
     let onDismiss: () -> Void
+    let onReduceFrequency: () -> Void
 
     @State private var showNoSlot = false
 
@@ -78,6 +79,10 @@ struct NudgeReminderSheet: View {
                     }
 
                     Button("Maybe later", action: onDismiss)
+                    Button("Remind me less often", action: onReduceFrequency)
+                        .font(.footnote)
+                        .foregroundStyle(.tertiary)
+                        .buttonStyle(.plain)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 10)
                         .foregroundStyle(.secondary)

--- a/Eta/Views/Settings/SettingsView.swift
+++ b/Eta/Views/Settings/SettingsView.swift
@@ -97,7 +97,31 @@ struct SettingsView: View {
                     ),
                     displayedComponents: .hourAndMinute
                 )
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Nudge frequency")
+                        Spacer()
+                        Text(nudgeFrequencyLabel(viewModel.preferences.nudgeFrequencyDays))
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(
+                        value: Binding(
+                            get: { Double(viewModel.preferences.nudgeFrequencyDays) },
+                            set: { viewModel.preferences.nudgeFrequencyDays = Int($0.rounded()) }
+                        ),
+                        in: 1...7,
+                        step: 1
+                    )
+                }
             }
+        }
+    }
+
+    private func nudgeFrequencyLabel(_ days: Int) -> String {
+        switch days {
+        case 1: return "Daily"
+        case 7: return "Weekly"
+        default: return "Every \(days) days"
         }
     }
 


### PR DESCRIPTION
## Summary

**6.2 Adjust**
- `nudgeFrequencyDays` (1–7, default daily) added to `UserPreferences` with full `Codable` support and migration for existing installs
- Frequency slider in Settings → Notifications with Daily / Every N days / Weekly labels
- `NudgeService` fires at the user's chosen notification time on the correct interval day; tracks `lastNudgeSentDate` in `UserDefaults`
- Phase-out: 3 consecutive "Maybe later" taps auto-bump frequency by one day; engagement (schedule / view suggestions) resets the counter
- "Remind me less often" button in `NudgeReminderSheet` immediately bumps frequency and dismisses

**6.3 Friends**
- Rotation: `NudgeService` skips the last-nudged contact when other overdue friends exist, cycling through the pool each day
- Friend nudge (send): "Nudge them" button in `FriendDetailView`; `onNudge` callback flows up through `ConnectionsView` → `MainTabView` → `InvitationManager.sendFriendNudge`
- Friend nudge (receive): `InvitationManager.pollFriendNudges` fetches `friend_nudges` rows addressed to the current user's identifier, fires a local notification, then deletes the rows
- SQL schema for `friend_nudges` table documented in `SupabaseService`