### PR TITLE
Add photo sharing and improve nudge card in check-in

### DIFF
--- a/ETA-imessage-extension/Info.plist
+++ b/ETA-imessage-extension/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>SUPABASE_URL</key>
+	<string>rcsttehfkfghynyzmjca.supabase.co</string>
+	<key>SUPABASE_ANON_KEY</key>
+	<string>sb_publishable_zE5ABZ_fDaDIoGLHbtx1pg_OlZAQICR</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>

--- a/Eta/App/MainTabView.swift
+++ b/Eta/App/MainTabView.swift
@@ -42,7 +42,8 @@ struct MainTabView: View {
                     settingsViewModel: settingsViewModel,
                     analyticsService: analyticsService,
                     weeklyCheckInState: weeklyCheckInState,
-                    onShowSettings: { showingSettings = true }
+                    onShowSettings: { showingSettings = true },
+                    photoRepository: photoRepository
                 )
                 .walkthrough(key: "friends", steps: TabWalkthroughs.friends)
             }

--- a/Eta/Config.xcconfig
+++ b/Eta/Config.xcconfig
@@ -23,5 +23,5 @@ LLM_API_KEY =
 // Supabase project URL and anon key — get from supabase.com → Project Settings → API
 // DO NOT PUSH TO REMOTE
 SUPABASE_URL = rcsttehfkfghynyzmjca.supabase.co
-SUPABASE_ANON_KEY = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJjc3R0ZWhma2ZnaHlueXptamNhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzg2ODAxODUsImV4cCI6MjA5NDI1NjE4NX0.LEKcnc98AM3zlTTmzX-Z_EUbqJT5-m1Xjsz6HsbaH7U
+SUPABASE_ANON_KEY = sb_publishable_zE5ABZ_fDaDIoGLHbtx1pg_OlZAQICR
 

--- a/Eta/EtaApp.swift
+++ b/Eta/EtaApp.swift
@@ -25,6 +25,7 @@ struct EtaApp: App {
     private let photoRepository: ActivityPhotoRepository
     private let reminderPhotoState: ReminderPhotoState
     private let supabaseService: SupabaseService
+    private let sharedPhotoSyncService: SharedPhotoSyncService
     private let phoneSetupService: PhoneSetupService
     @State private var hasPhoneSetup: Bool
     private let nudgeService: NudgeService
@@ -65,6 +66,10 @@ struct EtaApp: App {
 
         let supabaseService = SupabaseService()
         self.supabaseService = supabaseService
+        self.sharedPhotoSyncService = SharedPhotoSyncService(
+            supabaseService: supabaseService,
+            photoRepository: photoRepository
+        )
 
         let analyticsService = AnalyticsService(supabaseService: supabaseService)
         self.analyticsService = analyticsService
@@ -305,6 +310,7 @@ struct EtaApp: App {
             Task { await nudgeService.scheduleNudge() }
             Task { await weeklyCheckInService.scheduleIfNeeded() }
             Task { await invitationManager.pollForUpdates() }
+            Task { await sharedPhotoSyncService.sync() }
             if let id = phoneSetupService.myIdentifier {
                 Task { await supabaseService.registerDevice(identifier: id) }
             }

--- a/Eta/Info.plist
+++ b/Eta/Info.plist
@@ -2,6 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>eta</string>
+			</array>
+		</dict>
+	</array>
 	<key>DEMO_CONTACTS</key>
 	<string>$(DEMO_CONTACTS)</string>
 	<key>LLM_API_KEY</key>

--- a/Eta/Repositories/ActivityPhotoRepository.swift
+++ b/Eta/Repositories/ActivityPhotoRepository.swift
@@ -53,6 +53,16 @@ final class ActivityPhotoRepository {
         }
     }
 
+    /// All photos captured within the last `days` days. Used by SharedPhotoSyncService for upload.
+    func recentPhotos(withinDays days: Int) -> [ActivityPhoto] {
+        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: .now) ?? .distantPast
+        let descriptor = FetchDescriptor<ActivityPhoto>(
+            predicate: #Predicate { $0.capturedAt >= cutoff },
+            sortBy: [SortDescriptor(\.capturedAt, order: .reverse)]
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+
     func add(_ photo: ActivityPhoto) throws {
         modelContext.insert(photo)
         try modelContext.save()

--- a/Eta/Services/SharedPhotoSyncService.swift
+++ b/Eta/Services/SharedPhotoSyncService.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Syncs activity photos with friends via Supabase.
+///
+/// On every app foreground:
+/// - Uploads any local photos that haven't been shared yet
+/// - Downloads photos uploaded by friends and stores them in ActivityPhotoRepository
+///   so NudgeService can include them in nudge notifications automatically
+///
+/// Supabase table required (run in SQL editor):
+///
+/// CREATE TABLE shared_photos (
+///   id           TEXT PRIMARY KEY,
+///   uploader_id  TEXT NOT NULL,        -- devices.device_id of the uploader
+///   activity     TEXT NOT NULL,        -- Activity.rawValue
+///   image_data   TEXT NOT NULL,        -- base64-encoded JPEG
+///   created_at   TIMESTAMPTZ DEFAULT now()
+/// );
+/// ALTER TABLE shared_photos ENABLE ROW LEVEL SECURITY;
+/// CREATE POLICY "allow all" ON shared_photos FOR ALL USING (true) WITH CHECK (true);
+final class SharedPhotoSyncService {
+    private let supabaseService: SupabaseService
+    private let photoRepository: ActivityPhotoRepository
+
+    private static let lastDownloadKey = "me.Eta.sharedPhoto.lastDownload"
+    private static let uploadedIDsKey  = "me.Eta.sharedPhoto.uploadedIDs"
+
+    private var uploadedIDs: Set<String> {
+        get { Set(UserDefaults.standard.stringArray(forKey: Self.uploadedIDsKey) ?? []) }
+        set { UserDefaults.standard.set(Array(newValue), forKey: Self.uploadedIDsKey) }
+    }
+
+    init(supabaseService: SupabaseService, photoRepository: ActivityPhotoRepository) {
+        self.supabaseService = supabaseService
+        self.photoRepository = photoRepository
+    }
+
+    func sync() async {
+        guard supabaseService.isConfigured else { return }
+        async let up: () = upload()
+        async let down: () = download()
+        _ = await (up, down)
+    }
+
+    // MARK: - Private
+
+    /// Uploads local photos that haven't been shared yet (tracked by ID in UserDefaults).
+    private func upload() async {
+        let recent = photoRepository.recentPhotos(withinDays: 30)
+        var ids = uploadedIDs
+        for photo in recent where !ids.contains(photo.id.uuidString) {
+            await supabaseService.uploadSharedPhoto(
+                activity: photo.activityRawValue,
+                imageData: photo.imageData
+            )
+            ids.insert(photo.id.uuidString)
+        }
+        uploadedIDs = ids
+    }
+
+    /// Downloads photos uploaded by other devices since the last sync and stores them locally.
+    private func download() async {
+        let since = UserDefaults.standard.object(forKey: Self.lastDownloadKey) as? Date ?? .distantPast
+        let rows = await supabaseService.fetchNewSharedPhotos(since: since)
+        for row in rows {
+            guard let activity = Activity(rawValue: row.activity) else { continue }
+            let photo = ActivityPhoto(activity: activity, imageData: row.imageData)
+            try? photoRepository.add(photo)
+        }
+        if !rows.isEmpty {
+            UserDefaults.standard.set(Date(), forKey: Self.lastDownloadKey)
+        }
+    }
+}

--- a/Eta/Services/SupabaseService.swift
+++ b/Eta/Services/SupabaseService.swift
@@ -247,6 +247,42 @@ final class SupabaseService {
         try? await request(path: path, method: "DELETE")
     }
 
+    // MARK: - Shared photos
+    //
+    // Requires a shared_photos table in Supabase (see SharedPhotoSyncService.swift for SQL).
+
+    struct SharedPhotoRow {
+        let activity: String
+        let imageData: Data
+    }
+
+    func uploadSharedPhoto(activity: String, imageData: Data) async {
+        guard isConfigured else { return }
+        let body: [String: Any] = [
+            "id": UUID().uuidString,
+            "uploader_id": deviceID,
+            "activity": activity,
+            "image_data": imageData.base64EncodedString()
+        ]
+        try? await request(path: "/rest/v1/shared_photos", method: "POST", body: body)
+    }
+
+    func fetchNewSharedPhotos(since date: Date) async -> [SharedPhotoRow] {
+        guard isConfigured else { return [] }
+        let since = urlEncoded(iso(date))
+        let path = "/rest/v1/shared_photos?uploader_id=neq.\(deviceID)&created_at=gt.\(since)&select=activity,image_data&limit=50"
+        guard let data = try? await request(path: path, method: "GET"),
+              let rows = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return [] }
+        return rows.compactMap { row in
+            guard let activity = row["activity"] as? String,
+                  let base64 = row["image_data"] as? String,
+                  let imageData = Data(base64Encoded: base64)
+            else { return nil }
+            return SharedPhotoRow(activity: activity, imageData: imageData)
+        }
+    }
+
     // MARK: - Analytics
 
     func postAnalyticsEvent(

--- a/Eta/Views/Connections/ConnectionsView.swift
+++ b/Eta/Views/Connections/ConnectionsView.swift
@@ -7,6 +7,7 @@ struct ConnectionsView: View {
     let analyticsService: AnalyticsService
     let weeklyCheckInState: WeeklyCheckInState
     let onShowSettings: () -> Void
+    var photoRepository: ActivityPhotoRepository?
 
     @State private var searchText = ""
     @State private var showingAddSheet = false
@@ -65,7 +66,8 @@ struct ConnectionsView: View {
                             health: item.health,
                             displayName: homeViewModel.displayName(for: item.contact),
                             homeViewModel: homeViewModel,
-                            analyticsService: analyticsService
+                            analyticsService: analyticsService,
+                            photoRepository: photoRepository
                         )
                     } label: {
                         FriendSpotlightCard(
@@ -162,7 +164,8 @@ struct ConnectionsView: View {
                             ),
                             displayName: viewModel.displayName(for: contact),
                             homeViewModel: homeViewModel,
-                            analyticsService: analyticsService
+                            analyticsService: analyticsService,
+                            photoRepository: photoRepository
                         )
                     } label: {
                         ContactRow(contact: contact, viewModel: viewModel, activeFilter: viewModel.selectedTagFilter)

--- a/Eta/Views/Friends/CheckInSheet.swift
+++ b/Eta/Views/Friends/CheckInSheet.swift
@@ -10,6 +10,8 @@ struct CheckInSheet: View {
     let onSend: (String, Bool) -> Void
     let onDismiss: () -> Void
     var analyticsService: AnalyticsService?
+    /// A photo of the contact to include in the nudge card, if available.
+    var contactPhotoData: Data?
 
     enum AttachmentMode: String, CaseIterable {
         case none  = "None"
@@ -33,7 +35,8 @@ struct CheckInSheet: View {
         initialTemplate: String,
         onSend: @escaping (String, Bool) -> Void,
         onDismiss: @escaping () -> Void,
-        analyticsService: AnalyticsService? = nil
+        analyticsService: AnalyticsService? = nil,
+        contactPhotoData: Data? = nil
     ) {
         self.displayName = displayName
         self.givenName = givenName
@@ -42,6 +45,7 @@ struct CheckInSheet: View {
         self.onSend = onSend
         self.onDismiss = onDismiss
         self.analyticsService = analyticsService
+        self.contactPhotoData = contactPhotoData
         let personalized = initialTemplate.localizedCaseInsensitiveContains(givenName)
             ? initialTemplate
             : "Hey \(givenName)! \(initialTemplate)"
@@ -83,7 +87,7 @@ struct CheckInSheet: View {
                     }
 
                     if attachmentMode == .nudge {
-                        NudgeCardPreview()
+                        NudgeCardPreview(photoData: contactPhotoData)
                             .frame(maxWidth: .infinity)
                             .listRowInsets(.init(top: 12, leading: 12, bottom: 12, trailing: 12))
                     }
@@ -153,7 +157,7 @@ struct CheckInSheet: View {
 
         case .nudge:
             if MFMessageComposeViewController.canSendText(),
-               let data = renderNudgeCard() {
+               let data = renderNudgeCard(photoData: contactPhotoData) {
                 pendingAttachment = (data, "public.jpeg", "nudge.jpg")
                 showingComposer = true
             } else {
@@ -175,8 +179,8 @@ struct CheckInSheet: View {
     }
 
     @MainActor
-    private func renderNudgeCard() -> Data? {
-        let renderer = ImageRenderer(content: NudgeCardView())
+    private func renderNudgeCard(photoData: Data?) -> Data? {
+        let renderer = ImageRenderer(content: NudgeCardView(photoData: photoData))
         renderer.scale = 3.0
         return renderer.uiImage?.jpegData(compressionQuality: 0.9)
     }
@@ -185,36 +189,57 @@ struct CheckInSheet: View {
 // MARK: - Nudge card
 
 private struct NudgeCardView: View {
+    var photoData: Data?
     private let etaTeal = Color(red: 0.25, green: 0.48, blue: 0.46)
 
     var body: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .fill(etaTeal)
-                .frame(width: 260, height: 140)
+        ZStack(alignment: .bottom) {
+            if let data = photoData, let uiImage = UIImage(data: data) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 260, height: 160)
+                    .clipped()
+                    .overlay(
+                        LinearGradient(
+                            colors: [.clear, etaTeal.opacity(0.85)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+            } else {
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(etaTeal)
+                    .frame(width: 260, height: 160)
+            }
 
-            VStack(spacing: 10) {
+            VStack(spacing: 4) {
                 Image(systemName: "hand.wave.fill")
-                    .font(.system(size: 30, weight: .bold))
+                    .font(.system(size: 22, weight: .bold))
                     .foregroundStyle(.white)
                 Text("Thinking of you")
-                    .font(.system(size: 17, weight: .bold, design: .rounded))
+                    .font(.system(size: 16, weight: .bold, design: .rounded))
                     .foregroundStyle(.white)
                 Text("sent with Eta")
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.65))
+                    .foregroundStyle(.white.opacity(0.7))
             }
+            .padding(.bottom, 16)
         }
+        .frame(width: 260, height: 160)
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
     }
 }
 
 private struct NudgeCardPreview: View {
+    var photoData: Data?
+
     var body: some View {
         HStack {
             Spacer()
-            NudgeCardView()
+            NudgeCardView(photoData: photoData)
                 .scaleEffect(0.75)
-                .frame(height: 105)
+                .frame(height: 120)
             Spacer()
         }
     }

--- a/Eta/Views/Friends/FriendDetailView.swift
+++ b/Eta/Views/Friends/FriendDetailView.swift
@@ -7,6 +7,7 @@ struct FriendDetailView: View {
     let homeViewModel: HomeViewModel
     var analyticsService: AnalyticsService?
     var onAddGoal: (() -> Void)?
+    var photoRepository: ActivityPhotoRepository?
 
     @Environment(\.openURL) private var openURL
     @State private var showingGoalCreation = false
@@ -121,7 +122,8 @@ struct FriendDetailView: View {
                     showingCheckIn = false
                 },
                 onDismiss: { showingCheckIn = false },
-                analyticsService: analyticsService
+                analyticsService: analyticsService,
+                contactPhotoData: photoRepository?.photos(for: contact).first?.imageData
             )
             .onAppear { analyticsService?.logCheckInOpened(friendName: displayName) }
         }


### PR DESCRIPTION
## Summary

**Photo sharing (PRD 6.3 Friends)**
- New `SharedPhotoSyncService` runs on every app foreground: uploads your recent activity photos to Supabase and downloads photos uploaded by friends into your local `ActivityPhotoRepository`
- `NudgeService` already reads from `ActivityPhotoRepository`, so friends' photos automatically appear in nudge notifications with no additional wiring
- Upload is idempotent — tracks sent photo IDs in `UserDefaults` so the same photo is never re-uploaded
- Download fetches only photos from other devices, only newer than the last sync, capped at 50 per poll
- Supabase table SQL documented in `SharedPhotoSyncService.swift`

**Nudge card in CheckInSheet**
- The "Nudge" attachment mode in check-in now shows the contact's photo as the card background (teal gradient overlay) when one exists, falling back to the solid teal card if no photo is available
- `photoRepository` threaded as an optional through `MainTabView → ConnectionsView → FriendDetailView → CheckInSheet` — all existing call sites unaffected