### PR TITLE
Block scheduling conflicts across all entry points + inline warnings

### DIFF
--- a/Eta/App/MainTabView.swift
+++ b/Eta/App/MainTabView.swift
@@ -222,6 +222,7 @@ struct MainTabView: View {
                     invite: invite,
                     senderName: receivedInviteState.senderName,
                     isEdit: receivedInviteState.isEdit,
+                    hasConflict: invitationManager.hasConflict(start: invite.startTime, end: invite.endTime),
                     onAccept: {
                         receivedInviteState.clear()
                         Task {

--- a/Eta/Repositories/ScheduledHangoutRepository.swift
+++ b/Eta/Repositories/ScheduledHangoutRepository.swift
@@ -20,17 +20,18 @@ final class ScheduledHangoutRepository {
         guard try !hasOverlappingHangout(start: hangout.startDate, end: hangout.endDate) else {
             throw ScheduledHangoutRepositoryError.overlappingHangout
         }
-
         modelContext.insert(hangout)
         try modelContext.save()
         NotificationCenter.default.post(name: .scheduledHangoutsDidChange, object: nil)
     }
 
     /// Returns true when a non-canceled hangout already occupies any part of the interval.
-    func hasOverlappingHangout(start: Date, end: Date) throws -> Bool {
+    /// Pass `excludingID` to ignore a specific hangout (e.g. the one being edited).
+    func hasOverlappingHangout(start: Date, end: Date, excludingID: UUID? = nil) throws -> Bool {
         guard end > start else { return false }
 
         return try fetchUpcoming().contains {
+            $0.id != excludingID &&
             $0.status != .canceled &&
             $0.startDate < end &&
             $0.endDate > start

--- a/Eta/Services/InvitationManager.swift
+++ b/Eta/Services/InvitationManager.swift
@@ -259,6 +259,10 @@ final class InvitationManager {
         try? pendingReceivedRepo.deleteExpired()
     }
 
+    func hasConflict(start: Date, end: Date) -> Bool {
+        hasOverlappingScheduledHangout(start: start, end: end)
+    }
+
     private func hasOverlappingScheduledHangout(start: Date, end: Date) -> Bool {
         guard end > start else { return false }
 

--- a/Eta/Services/InviteService.swift
+++ b/Eta/Services/InviteService.swift
@@ -31,6 +31,10 @@ final class InviteService {
         return hangout.id
     }
 
+    func hasConflict(for interval: DateInterval) -> Bool {
+        (try? hangoutRepository.hasOverlappingHangout(start: interval.start, end: interval.end)) ?? false
+    }
+
     /// Opens Messages with a pre-filled invite text.
     /// Call this when the user taps "Send Invite" on the confirmation screen.
     func sendMessage(for suggestion: Suggestion) {

--- a/Eta/ViewModels/ChatViewModel.swift
+++ b/Eta/ViewModels/ChatViewModel.swift
@@ -115,7 +115,10 @@ final class ChatViewModel {
                 proposedTimes: [interval],
                 generatedAt: .now
             )
-            guard let hangoutID = inviteService.book(suggestion: suggestion) else { return }
+            guard let hangoutID = inviteService.book(suggestion: suggestion) else {
+                messages.append(ChatMessage(role: .assistant, content: "You already have an event at that time. Try a different time."))
+                return
+            }
             _ = try? await invitationManager.acceptSuggestion(
                 contact: contact,
                 activityName: activity,

--- a/Eta/ViewModels/SuggestionViewModel.swift
+++ b/Eta/ViewModels/SuggestionViewModel.swift
@@ -17,7 +17,6 @@ final class SuggestionViewModel {
     private(set) var suggestion: Suggestion?
     private(set) var isLoading: Bool = false
     private(set) var scheduleState: ScheduleState = .idle
-    private(set) var hasSchedulingConflict = false
 
     private let suggestionService: SuggestionService
     private let inviteService: InviteService
@@ -133,6 +132,12 @@ final class SuggestionViewModel {
         suggestion = nil
     }
 
+    func hasConflict(for time: Date) -> Bool {
+        guard let s = suggestion else { return false }
+        let interval = DateInterval(start: time, duration: s.proposedTime.duration)
+        return invitationManager.hasConflict(start: interval.start, end: interval.end)
+    }
+
     /// Replaces the current suggestion's activity and start time without re-running the engine.
     /// The original duration is preserved; only the start is shifted to `time`.
     func customize(activity: String, time: Date) {
@@ -156,10 +161,7 @@ final class SuggestionViewModel {
         let scheduledTime = suggestion.proposedTime.start
 
         let contact = suggestion.contact
-        guard let hangoutID = inviteService.book(suggestion: suggestion) else {
-            hasSchedulingConflict = true
-            return
-        }
+        guard let hangoutID = inviteService.book(suggestion: suggestion) else { return }
         let endDate = suggestion.proposedTime.end
 
         Task { @MainActor in
@@ -183,11 +185,7 @@ final class SuggestionViewModel {
         scheduleState = .idle
     }
 
-    func dismissSchedulingConflict() {
-        hasSchedulingConflict = false
-    }
-
-    /// Schedules a hangout built from outside this ViewModel (e.g. nudge sheet).
+/// Schedules a hangout built from outside this ViewModel (e.g. nudge sheet).
     /// Drives the same accepted → invitationSent flow as a normal schedule() call.
     func scheduleFromNudge(_ suggestion: Suggestion) {
         self.suggestion = suggestion

--- a/Eta/ViewModels/UpcomingEventsViewModel.swift
+++ b/Eta/ViewModels/UpcomingEventsViewModel.swift
@@ -85,6 +85,10 @@ final class UpcomingEventsViewModel {
         await refresh()
     }
 
+    func hasConflict(for interval: DateInterval, excludingID: UUID? = nil) -> Bool {
+        (try? hangoutRepository.hasOverlappingHangout(start: interval.start, end: interval.end, excludingID: excludingID)) ?? false
+    }
+
     // MARK: - CRUD
 
     /// Books a new hangout and sends an invitation via InvitationManager.

--- a/Eta/Views/Reminders/ReceivedInviteSheet.swift
+++ b/Eta/Views/Reminders/ReceivedInviteSheet.swift
@@ -4,6 +4,7 @@ struct ReceivedInviteSheet: View {
     let invite: RemoteInvitation
     let senderName: String
     let isEdit: Bool
+    let hasConflict: Bool
     let onAccept: () -> Void
     let onDecline: () -> Void
     let onDismissedWithoutResponse: () -> Void
@@ -27,6 +28,11 @@ struct ReceivedInviteSheet: View {
                 Text(formattedTime)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
+                if hasConflict {
+                    Label("You already have an event at this time", systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
             }
             .padding(.horizontal, 24)
 
@@ -35,6 +41,7 @@ struct ReceivedInviteSheet: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
                     .buttonStyle(.borderedProminent)
+                    .disabled(hasConflict)
 
                 Button("Decline") { responded = true; onDecline() }
                     .frame(maxWidth: .infinity)

--- a/Eta/Views/Suggestion/SuggestionDetailSheet.swift
+++ b/Eta/Views/Suggestion/SuggestionDetailSheet.swift
@@ -7,6 +7,7 @@ struct SuggestionDetailSheet: View {
     let initialTime: Date
     let onConfirm: (String, Date) -> Void
     let onDismiss: () -> Void
+    var conflictChecker: ((Date) -> Bool)?
 
     @State private var selectedActivity: String
     @State private var selectedTime: Date
@@ -17,7 +18,8 @@ struct SuggestionDetailSheet: View {
         initialActivity: String,
         initialTime: Date,
         onConfirm: @escaping (String, Date) -> Void,
-        onDismiss: @escaping () -> Void
+        onDismiss: @escaping () -> Void,
+        conflictChecker: ((Date) -> Bool)? = nil
     ) {
         self.displayName = displayName
         self.reason = reason
@@ -25,6 +27,7 @@ struct SuggestionDetailSheet: View {
         self.initialTime = initialTime
         self.onConfirm = onConfirm
         self.onDismiss = onDismiss
+        self.conflictChecker = conflictChecker
         _selectedActivity = State(initialValue: initialActivity)
         _selectedTime = State(initialValue: initialTime)
     }
@@ -64,6 +67,11 @@ struct SuggestionDetailSheet: View {
                         in: Date()...,
                         displayedComponents: [.date, .hourAndMinute]
                     )
+                    if let checker = conflictChecker, checker(selectedTime) {
+                        Label("You already have an event at this time", systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
                 }
             }
             .navigationTitle("Customize")
@@ -76,6 +84,7 @@ struct SuggestionDetailSheet: View {
                     Button("Done") {
                         onConfirm(selectedActivity, selectedTime)
                     }
+                    .disabled(conflictChecker?(selectedTime) == true)
                 }
             }
             .onChange(of: initialActivity) { _, newActivity in

--- a/Eta/Views/Suggestion/SuggestionView.swift
+++ b/Eta/Views/Suggestion/SuggestionView.swift
@@ -132,13 +132,6 @@ struct SuggestionView: View {
             diffSuggestions = []
         }
         .trackScreen("SuggestionView", analytics: analyticsService)
-        .alert("Hangout already scheduled", isPresented: schedulingConflictBinding) {
-            Button("OK", role: .cancel) {
-                viewModel.dismissSchedulingConflict()
-            }
-        } message: {
-            Text("Pick a different time.")
-        }
         .sheet(isPresented: $showingCustomize) {
             if let suggestion = viewModel.suggestion {
                 SuggestionDetailSheet(
@@ -150,7 +143,8 @@ struct SuggestionView: View {
                         viewModel.customize(activity: activity, time: time)
                         showingCustomize = false
                     },
-                    onDismiss: { showingCustomize = false }
+                    onDismiss: { showingCustomize = false },
+                    conflictChecker: { viewModel.hasConflict(for: $0) }
                 )
             }
         }
@@ -298,16 +292,6 @@ struct SuggestionView: View {
         )
     }
 
-    private var schedulingConflictBinding: Binding<Bool> {
-        Binding(
-            get: { viewModel.hasSchedulingConflict },
-            set: { isPresented in
-                if !isPresented {
-                    viewModel.dismissSchedulingConflict()
-                }
-            }
-        )
-    }
 }
 
 // MARK: - Confirmation views

--- a/Eta/Views/UpcomingEvents/AddEditEventSheet.swift
+++ b/Eta/Views/UpcomingEvents/AddEditEventSheet.swift
@@ -14,6 +14,7 @@ struct AddEditEventSheet: View {
     let mode: Mode
     let onSave: (TrackedContact, String, DateInterval) async -> Void
     let onSuggestActivity: (TrackedContact, DateInterval) async throws -> String?
+    var conflictChecker: ((DateInterval) -> Bool)?
 
     @State private var selectedContactID: UUID?
     @State private var activityInputMode: ActivityInputMode = .preset
@@ -43,7 +44,7 @@ struct AddEditEventSheet: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") { save() }
-                        .disabled(!canSave)
+                        .disabled(!canSave || hasConflict)
                 }
             }
         }
@@ -133,6 +134,11 @@ struct AddEditEventSheet: View {
                 Text("2 hours").tag(2.0)
                 Text("3 hours").tag(3.0)
             }
+            if hasConflict {
+                Label("You already have an event at this time", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
         }
     }
 
@@ -163,6 +169,11 @@ struct AddEditEventSheet: View {
         case .preset: return selectedPreset.rawValue
         case .custom: return customText.trimmingCharacters(in: .whitespaces)
         }
+    }
+
+    private var hasConflict: Bool {
+        guard let checker = conflictChecker else { return false }
+        return checker(DateInterval(start: startDate, duration: durationHours * 3600))
     }
 
     private var canSave: Bool {

--- a/Eta/Views/UpcomingEvents/ReceivedInviteCard.swift
+++ b/Eta/Views/UpcomingEvents/ReceivedInviteCard.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ReceivedInviteCard: View {
     let invite: PendingReceivedInvitation
+    let hasConflict: Bool
     let onAccept: () -> Void
     let onDecline: () -> Void
 
@@ -16,6 +17,11 @@ struct ReceivedInviteCard: View {
                 Text(formattedTime)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                if hasConflict {
+                    Label("You already have an event at this time", systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
             }
 
             HStack(spacing: 10) {
@@ -27,6 +33,7 @@ struct ReceivedInviteCard: View {
                 Button("Accept", action: onAccept)
                     .frame(maxWidth: .infinity)
                     .buttonStyle(.borderedProminent)
+                    .disabled(hasConflict)
             }
         }
         .padding()

--- a/Eta/Views/UpcomingEvents/UpcomingEventsDashboard.swift
+++ b/Eta/Views/UpcomingEvents/UpcomingEventsDashboard.swift
@@ -24,6 +24,7 @@ struct UpcomingEventsDashboard: View {
                             ForEach(viewModel.pendingInvites) { invite in
                                 ReceivedInviteCard(
                                     invite: invite,
+                                    hasConflict: viewModel.hasConflict(for: DateInterval(start: invite.startTime, end: invite.endTime)),
                                     onAccept: { Task { await viewModel.respond(to: invite, accepted: true) } },
                                     onDecline: { Task { await viewModel.respond(to: invite, accepted: false) } }
                                 )
@@ -87,7 +88,8 @@ struct UpcomingEventsDashboard: View {
                 },
                 onSuggestActivity: { contact, proposedTime in
                     try await viewModel.suggestActivity(for: contact, proposedTime: proposedTime)
-                }
+                },
+                conflictChecker: { viewModel.hasConflict(for: $0) }
             )
         }
         .sheet(item: $editingItem) { item in
@@ -99,7 +101,8 @@ struct UpcomingEventsDashboard: View {
                 },
                 onSuggestActivity: { contact, proposedTime in
                     try await viewModel.suggestActivity(for: contact, proposedTime: proposedTime)
-                }
+                },
+                conflictChecker: { viewModel.hasConflict(for: $0, excludingID: item.hangout.id) }
             )
         }
         .trackScreen("UpcomingEventsDashboard", analytics: analyticsService)


### PR DESCRIPTION
## Summary
- Block scheduling conflicts across all entry points — overlapping pending/confirmed hangouts prevent saving or accepting
- Grey out Save in Add/Edit event sheet with orange warning when selected time conflicts
- Grey out Done in SuggestionDetailSheet with orange warning when customized time conflicts (edit excludes self)
- Grey out Accept in ReceivedInviteSheet and ReceivedInviteCard on conflict; Decline and Answer Later remain enabled; Accept ungreys on the card once the conflict clears
- Re-add backend conflict block in InvitationManager as safety net for notification direct-accept path
- Chat blocks booking on conflict and surfaces an inline message
- Only pending and confirmed hangouts count as conflicts; canceled/declined do not

## Test plan
- **Add event**: create an event at 2pm, tap + again and pick the same time → Save greyed out with orange warning
- **Edit event**: with two events, edit one to overlap the other → Save greyed out; edit it to its own time → no warning (self excluded)
-  **SuggestionDetailSheet**: create an event at tomorrow 3pm, get a suggestion, tap customize, change time to tomorrow 3pm → Done greyed out
-  **Chat**: create an event at a known time, ask chat to schedule with a friend at that exact time → inline "already have an event" message, no booking
- **ReceivedInviteSheet** *(two devices)*: device B has an event at 3pm, device A sends invite for 3pm → device B's sheet shows Accept greyed out, Decline and Answer Later work
-  **ReceivedInviteCard ungreys** *(two devices)*: same setup, device B taps Answer Later → card persists with Accept greyed out → device B deletes the conflicting event → pull to refresh → Accept ungreys